### PR TITLE
add definitions for xim preedit callback

### DIFF
--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -2538,7 +2538,7 @@ pub type XIMFeedback = c_ulong;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
-pub struct XIMPreeditCaretCallbackStruct {
+pub struct XIMPreeditDrawCallbackStruct {
     pub caret: c_int,
     pub chg_first: c_int,
     pub chg_length: c_int,
@@ -2547,7 +2547,7 @@ pub struct XIMPreeditCaretCallbackStruct {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
-pub struct XIMPreeditDrawCallbackStruct {
+pub struct XIMPreeditCaretCallbackStruct {
     pub position: c_int,
     pub direction: XIMCaretDirection,
     pub style: XIMCaretStyle,

--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -2509,6 +2509,66 @@ pub struct XIMCallback {
     pub callback: XIMProc,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[repr(C)]
+pub enum XIMCaretDirection {
+    XIMForwardChar,
+    XIMBackwardChar,
+    XIMForwardWord,
+    XIMBackwardWord,
+    XIMCaretUp,
+    XIMCaretDown,
+    XIMNextLine,
+    XIMPreviousLine,
+    XIMLineStart,
+    XIMLineEnd,
+    XIMAbsolutePosition,
+    XIMDontChange,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[repr(C)]
+pub enum XIMCaretStyle {
+    XIMIsInvisible,
+    XIMIsPrimary,
+    XIMIsSecondary,
+}
+
+pub type XIMFeedback = c_ulong;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[repr(C)]
+pub struct XIMPreeditCaretCallbackStruct {
+    pub caret: c_int,
+    pub chg_first: c_int,
+    pub chg_length: c_int,
+    pub text: *mut XIMText,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[repr(C)]
+pub struct XIMPreeditDrawCallbackStruct {
+    pub position: c_int,
+    pub direction: XIMCaretDirection,
+    pub style: XIMCaretStyle,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub union XIMTextString {
+  pub multi_byte: *mut c_char,
+  pub wide_char: wchar_t,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct XIMText {
+  pub length: c_ushort,
+  pub feedback: *mut XIMFeedback,
+  pub encoding_is_wchar: Bool,
+  pub string: XIMTextString,
+}
+
 #[repr(C)]
 pub struct XICCallback {
     pub client_data: XPointer,


### PR DESCRIPTION
added `XIMPreeditCaretCallback`, `XIMPreeditDrawCallback`, and its related
type definition
`XIMTextString` type doesn't exist in x11 library itself, but it is
necessary to define `string` field in `XIMText` struct