### PR TITLE
Modify the X11 crate for no_std

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,16 @@ build-x11:
 build-x11-dl:
 	cd x11-dl && cargo build
 
-tests: tests-x11 tests-x11-dl
+tests: tests-x11 tests-x11-dl tests-x11-nostd
 
 tests-x11:
 	cd x11 && cargo test
 
 tests-x11-dl:
 	cd x11-dl && cargo test
+
+tests-x11-nostd:
+	cd x11 && cargo test --no-default-features
 
 docs: docs-x11 docs-x11-dl
 

--- a/src/dpms.rs
+++ b/src/dpms.rs
@@ -2,16 +2,14 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{ c_int };
+use crate::os_primitives::c_int;
 
-use xlib::{ Display, Status, Bool };
-use xmd::{ CARD16, BOOL };
-
+use xlib::{Bool, Display, Status};
+use xmd::{BOOL, CARD16};
 
 //
 // functions
 //
-
 
 x11_link! { Xext, xext, ["libXext.so.6", "libXext.so"], 9,
   pub fn DPMSQueryExtension (_1: *mut Display, _2: *mut c_int, _3: *mut c_int) -> Bool,
@@ -27,11 +25,9 @@ variadic:
 globals:
 }
 
-
 //
 // constants
 //
-
 
 pub const DPMSMajorVersion: c_int = 1;
 pub const DPMSMinorVersion: c_int = 1;

--- a/src/glx.rs
+++ b/src/glx.rs
@@ -2,25 +2,13 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{
-  c_char,
-  c_int,
-  c_uchar,
-  c_uint,
-  c_ulong,
-};
+use crate::os_primitives::{c_char, c_int, c_uchar, c_uint, c_ulong};
 
-use ::xlib::{
-  Display,
-  XID,
-  XVisualInfo,
-};
-
+use ::xlib::{Display, XVisualInfo, XID};
 
 //
 // functions
 //
-
 
 x11_link! { Glx, gl, ["libGL.so.1", "libGL.so"], 40,
   pub fn glXChooseFBConfig (_4: *mut Display, _3: c_int, _2: *const c_int, _1: *mut c_int) -> *mut GLXFBConfig,
@@ -67,15 +55,15 @@ variadic:
 globals:
 }
 
-
 //
 // types
 //
 
-
 // opaque structures
-#[repr(C)] pub struct __GLXcontextRec;
-#[repr(C)] pub struct __GLXFBConfigRec;
+#[repr(C)]
+pub struct __GLXcontextRec;
+#[repr(C)]
+pub struct __GLXFBConfigRec;
 
 // types
 pub type GLXContext = *mut __GLXcontextRec;
@@ -87,11 +75,9 @@ pub type GLXPbuffer = XID;
 pub type GLXPixmap = XID;
 pub type GLXWindow = XID;
 
-
 //
 // constants
 //
-
 
 // config caveats
 pub const GLX_SLOW_CONFIG: c_int = 0x8001;
@@ -210,40 +196,36 @@ pub const GLX_SAVED: c_int = 0x8021;
 pub const GLX_WINDOW: c_int = 0x8022;
 pub const GLX_PBUFFER: c_int = 0x8023;
 
-
 //
 // ARB extensions
 //
 
-
 pub mod arb {
-  use std::os::raw::c_int;
+    use crate::os_primitives::c_int;
 
-  // context attributes
-  pub const GLX_CONTEXT_MAJOR_VERSION_ARB: c_int = 0x2091;
-  pub const GLX_CONTEXT_MINOR_VERSION_ARB: c_int = 0x2092;
-  pub const GLX_CONTEXT_FLAGS_ARB: c_int = 0x2094;
-  pub const GLX_CONTEXT_PROFILE_MASK_ARB: c_int = 0x9126;
+    // context attributes
+    pub const GLX_CONTEXT_MAJOR_VERSION_ARB: c_int = 0x2091;
+    pub const GLX_CONTEXT_MINOR_VERSION_ARB: c_int = 0x2092;
+    pub const GLX_CONTEXT_FLAGS_ARB: c_int = 0x2094;
+    pub const GLX_CONTEXT_PROFILE_MASK_ARB: c_int = 0x9126;
 
-  // context flags
-  pub const GLX_CONTEXT_DEBUG_BIT_ARB: c_int = 0x0001;
-  pub const GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB: c_int = 0x0002;
+    // context flags
+    pub const GLX_CONTEXT_DEBUG_BIT_ARB: c_int = 0x0001;
+    pub const GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB: c_int = 0x0002;
 
-  // context profile mask
-  pub const GLX_CONTEXT_CORE_PROFILE_BIT_ARB: c_int = 0x0001;
-  pub const GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB: c_int = 0x0002;
+    // context profile mask
+    pub const GLX_CONTEXT_CORE_PROFILE_BIT_ARB: c_int = 0x0001;
+    pub const GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB: c_int = 0x0002;
 }
-
 
 //
 // EXT extensions
 //
 
-
 pub mod ext {
-  use std::os::raw::c_int;
+    use crate::os_primitives::c_int;
 
-  // drawable attributes
-  pub const GLX_SWAP_INTERVAL_EXT: c_int = 0x20f1;
-  pub const GLX_MAX_SWAP_INTERVAL_EXT: c_int = 0x20f2;
+    // drawable attributes
+    pub const GLX_SWAP_INTERVAL_EXT: c_int = 0x20f1;
+    pub const GLX_MAX_SWAP_INTERVAL_EXT: c_int = 0x20f2;
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -2,40 +2,38 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::cmp::min;
-use std::mem::{
-  size_of,
-  zeroed,
-};
-
+use core::cmp::min;
+use core::mem::{size_of, zeroed};
 
 //
 // public functions
 //
 
+pub unsafe fn mem_eq<T: Sized>(a: &T, b: &T) -> bool {
+    let a_addr = a as *const T as usize;
+    let b_addr = b as *const T as usize;
 
-pub unsafe fn mem_eq<T: Sized> (a: &T, b: &T) -> bool {
-  let a_addr = a as *const T as usize;
-  let b_addr = b as *const T as usize;
-
-  for i in 0..size_of::<T>() {
-    if *((a_addr + i) as *const u8) != *((b_addr + i) as *const u8) {
-      return false;
+    for i in 0..size_of::<T>() {
+        if *((a_addr + i) as *const u8) != *((b_addr + i) as *const u8) {
+            return false;
+        }
     }
-  }
 
-  return true;
+    return true;
 }
 
-pub unsafe fn transmute_union<I, O> (input: &I) -> O
-  where I : Sized, O : Sized
+pub unsafe fn transmute_union<I, O>(input: &I) -> O
+where
+    I: Sized,
+    O: Sized,
 {
-  let mut output: O = zeroed();
-  let copy_len = min(size_of::<I>(), size_of::<O>());
+    let mut output: O = zeroed();
+    let copy_len = min(size_of::<I>(), size_of::<O>());
 
-  for i in 0..copy_len {
-    *((&mut output as *mut O as usize + i) as *mut u8) = *((input as *const I as usize + i) as *const u8);
-  }
+    for i in 0..copy_len {
+        *((&mut output as *mut O as usize + i) as *mut u8) =
+            *((input as *const I as usize + i) as *const u8);
+    }
 
-  return output;
+    return output;
 }

--- a/src/keysym.rs
+++ b/src/keysym.rs
@@ -2,7 +2,7 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::c_uint;
+use crate::os_primitives::c_uint;
 
 pub const XK_BackSpace: c_uint = 0xFF08;
 pub const XK_Tab: c_uint = 0xFF09;

--- a/src/xcursor.rs
+++ b/src/xcursor.rs
@@ -2,29 +2,14 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{
-  c_char,
-  c_int,
-  c_long,
-  c_uchar,
-  c_uint,
-  c_ulong,
-  c_void,
-};
 use libc::FILE;
+use crate::os_primitives::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 
-use ::xlib::{
-  Cursor,
-  Display,
-  XColor,
-  XImage,
-};
-
+use ::xlib::{Cursor, Display, XColor, XImage};
 
 //
 // functions
 //
-
 
 x11_link! { Xcursor, xcursor, ["libXcursor.so.1", "libXcursor.so"], 59,
   pub fn XcursorAnimateCreate (_1: *mut XcursorCursors) -> *mut XcursorAnimate,
@@ -90,11 +75,9 @@ variadic:
 globals:
 }
 
-
 //
 // types
 //
-
 
 pub type XcursorBool = c_int;
 pub type XcursorDim = XcursorUInt;
@@ -104,108 +87,108 @@ pub type XcursorUInt = c_uint;
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct _XcursorAnimate {
-  pub cursors: *mut XcursorCursors,
-  pub sequence: c_int,
+    pub cursors: *mut XcursorCursors,
+    pub sequence: c_int,
 }
 pub type XcursorAnimate = _XcursorAnimate;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct _XcursorChunkHeader {
-  pub header: XcursorUInt,
-  pub type_: XcursorUInt,
-  pub subtype: XcursorUInt,
-  pub version: XcursorUInt,
+    pub header: XcursorUInt,
+    pub type_: XcursorUInt,
+    pub subtype: XcursorUInt,
+    pub version: XcursorUInt,
 }
 pub type XcursorChunkHeader = _XcursorChunkHeader;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct _XcursorComment {
-  pub version: XcursorUInt,
-  pub comment_type: XcursorUInt,
-  pub comment: *mut c_char,
+    pub version: XcursorUInt,
+    pub comment_type: XcursorUInt,
+    pub comment: *mut c_char,
 }
 pub type XcursorComment = _XcursorComment;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct _XcursorComments {
-  pub ncomment: c_int,
-  pub comments: *mut *mut XcursorComment,
+    pub ncomment: c_int,
+    pub comments: *mut *mut XcursorComment,
 }
 pub type XcursorComments = _XcursorComments;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct _XcursorCursors {
-  pub dpy: *mut Display,
-  pub ref_: c_int,
-  pub ncursor: c_int,
-  pub cursors: *mut Cursor,
+    pub dpy: *mut Display,
+    pub ref_: c_int,
+    pub ncursor: c_int,
+    pub cursors: *mut Cursor,
 }
 pub type XcursorCursors = _XcursorCursors;
 
 #[derive(Debug, Copy)]
 #[repr(C)]
 pub struct _XcursorFile {
-  pub closure: *mut c_void,
-  pub read: Option<unsafe extern "C" fn (*mut XcursorFile, *mut c_uchar, c_int) -> c_int>,
-  pub write: Option<unsafe extern "C" fn (*mut XcursorFile, *mut c_uchar, c_int) -> c_int>,
-  pub seek: Option<unsafe extern "C" fn (*mut XcursorFile, c_long, c_int) -> c_int>,
+    pub closure: *mut c_void,
+    pub read: Option<unsafe extern "C" fn(*mut XcursorFile, *mut c_uchar, c_int) -> c_int>,
+    pub write: Option<unsafe extern "C" fn(*mut XcursorFile, *mut c_uchar, c_int) -> c_int>,
+    pub seek: Option<unsafe extern "C" fn(*mut XcursorFile, c_long, c_int) -> c_int>,
 }
 pub type XcursorFile = _XcursorFile;
 
 impl Clone for _XcursorFile {
-  fn clone (&self) -> _XcursorFile {
-    _XcursorFile {
-      closure: self.closure,
-      read: self.read,
-      write: self.write,
-      seek: self.seek,
+    fn clone(&self) -> _XcursorFile {
+        _XcursorFile {
+            closure: self.closure,
+            read: self.read,
+            write: self.write,
+            seek: self.seek,
+        }
     }
-  }
 }
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct _XcursorFileHeader {
-  pub magic: XcursorUInt,
-  pub header: XcursorUInt,
-  pub version: XcursorUInt,
-  pub ntoc: XcursorUInt,
-  pub tocs: *mut XcursorFileToc,
+    pub magic: XcursorUInt,
+    pub header: XcursorUInt,
+    pub version: XcursorUInt,
+    pub ntoc: XcursorUInt,
+    pub tocs: *mut XcursorFileToc,
 }
 pub type XcursorFileHeader = _XcursorFileHeader;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct _XcursorFileToc {
-  pub type_: XcursorUInt,
-  pub subtype: XcursorUInt,
-  pub position: XcursorUInt,
+    pub type_: XcursorUInt,
+    pub subtype: XcursorUInt,
+    pub position: XcursorUInt,
 }
 pub type XcursorFileToc = _XcursorFileToc;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct _XcursorImage {
-  pub version: XcursorUInt,
-  pub size: XcursorDim,
-  pub width: XcursorDim,
-  pub height: XcursorDim,
-  pub xhot: XcursorDim,
-  pub yhot: XcursorDim,
-  pub delay: XcursorUInt,
-  pub pixels: *mut XcursorPixel,
+    pub version: XcursorUInt,
+    pub size: XcursorDim,
+    pub width: XcursorDim,
+    pub height: XcursorDim,
+    pub xhot: XcursorDim,
+    pub yhot: XcursorDim,
+    pub delay: XcursorUInt,
+    pub pixels: *mut XcursorPixel,
 }
 pub type XcursorImage = _XcursorImage;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct _XcursorImages {
-  pub nimage: c_int,
-  pub images: *mut *mut XcursorImage,
-  pub name: *mut c_char,
+    pub nimage: c_int,
+    pub images: *mut *mut XcursorImage,
+    pub name: *mut c_char,
 }
 pub type XcursorImages = _XcursorImages;

--- a/src/xf86vmode.rs
+++ b/src/xf86vmode.rs
@@ -2,29 +2,13 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{
-  c_char,
-  c_float,
-  c_int,
-  c_uchar,
-  c_uint,
-  c_ulong,
-  c_ushort,
-};
+use crate::os_primitives::{c_char, c_float, c_int, c_uchar, c_uint, c_ulong, c_ushort};
 
-use ::xlib::{
-  Bool,
-  Display,
-  Time,
-  Window,
-  XEvent,
-};
-
+use ::xlib::{Bool, Display, Time, Window, XEvent};
 
 //
 // functions
 //
-
 
 x11_link! { Xf86vmode, xxf86vm, ["libXxf86vm.so.1", "libXxf86vm.so"], 22,
   pub fn XF86VidModeAddModeLine (_4: *mut Display, _3: c_int, _2: *mut XF86VidModeModeInfo, _1: *mut XF86VidModeModeInfo) -> c_int,
@@ -53,92 +37,88 @@ variadic:
 globals:
 }
 
-
 //
 // types
 //
 
-
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct XF86VidModeGamma {
-  pub red: c_float,
-  pub green: c_float,
-  pub blue: c_float,
+    pub red: c_float,
+    pub green: c_float,
+    pub blue: c_float,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XF86VidModeModeInfo {
-  pub dotclock: c_uint,
-  pub hdisplay: c_ushort,
-  pub hsyncstart: c_ushort,
-  pub hsyncend: c_ushort,
-  pub htotal: c_ushort,
-  pub hskew: c_ushort,
-  pub vdisplay: c_ushort,
-  pub vsyncstart: c_ushort,
-  pub vsyncend: c_ushort,
-  pub vtotal: c_ushort,
-  pub flags: c_uint,
-  pub privsize: c_int,
-  pub private: *mut i32,
+    pub dotclock: c_uint,
+    pub hdisplay: c_ushort,
+    pub hsyncstart: c_ushort,
+    pub hsyncend: c_ushort,
+    pub htotal: c_ushort,
+    pub hskew: c_ushort,
+    pub vdisplay: c_ushort,
+    pub vsyncstart: c_ushort,
+    pub vsyncend: c_ushort,
+    pub vtotal: c_ushort,
+    pub flags: c_uint,
+    pub privsize: c_int,
+    pub private: *mut i32,
 }
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct XF86VidModeModeLine {
-  pub hdisplay: c_ushort,
-  pub hsyncstart: c_ushort,
-  pub hsyncend: c_ushort,
-  pub htotal: c_ushort,
-  pub hskew: c_ushort,
-  pub vdisplay: c_ushort,
-  pub vsyncstart: c_ushort,
-  pub vsyncend: c_ushort,
-  pub vtotal: c_ushort,
-  pub flags: c_uint,
-  pub privsize: c_int,
-  pub private: *mut i32,
+    pub hdisplay: c_ushort,
+    pub hsyncstart: c_ushort,
+    pub hsyncend: c_ushort,
+    pub htotal: c_ushort,
+    pub hskew: c_ushort,
+    pub vdisplay: c_ushort,
+    pub vsyncstart: c_ushort,
+    pub vsyncend: c_ushort,
+    pub vtotal: c_ushort,
+    pub flags: c_uint,
+    pub privsize: c_int,
+    pub private: *mut i32,
 }
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct XF86VidModeMonitor {
-  pub vendor: *mut c_char,
-  pub model: *mut c_char,
-  pub EMPTY: c_float,
-  pub nhsync: c_uchar,
-  pub hsync: *mut XF86VidModeSyncRange,
-  pub nvsync: c_uchar,
-  pub vsync: *mut XF86VidModeSyncRange,
+    pub vendor: *mut c_char,
+    pub model: *mut c_char,
+    pub EMPTY: c_float,
+    pub nhsync: c_uchar,
+    pub hsync: *mut XF86VidModeSyncRange,
+    pub nvsync: c_uchar,
+    pub vsync: *mut XF86VidModeSyncRange,
 }
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct XF86VidModeSyncRange {
-  pub hi: c_float,
-  pub lo: c_float,
+    pub hi: c_float,
+    pub lo: c_float,
 }
-
 
 //
 // event structures
 //
 
-
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct XF86VidModeNotifyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub root: Window,
-  pub state: c_int,
-  pub kind: c_int,
-  pub forced: Bool,
-  pub time: Time,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub root: Window,
+    pub state: c_int,
+    pub kind: c_int,
+    pub forced: Bool,
+    pub time: Time,
 }
 
 event_conversions_and_tests! {

--- a/src/xfixes.rs
+++ b/src/xfixes.rs
@@ -4,10 +4,8 @@
 
 use ::xlib::XID;
 
-
 //
 // types
 //
-
 
 pub type PointerBarrier = XID;

--- a/src/xft.rs
+++ b/src/xft.rs
@@ -2,16 +2,14 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::*;
+use crate::os_primitives::*;
 
 use xlib::{Display, Region, Visual, XRectangle};
 use xrender::{XGlyphInfo, XRenderColor};
 
-
 //
 // external types
 //
-
 
 // freetype
 pub enum FT_FaceRec {}
@@ -23,16 +21,23 @@ pub enum FcCharSet {}
 pub enum FcPattern {}
 
 #[repr(C)]
-pub enum FcEndian { Big, Little }
+pub enum FcEndian {
+    Big,
+    Little,
+}
 
 #[repr(C)]
-pub enum FcResult { Match, NoMatch, TypeMismatch, NoId, OutOfMemory }
-
+pub enum FcResult {
+    Match,
+    NoMatch,
+    TypeMismatch,
+    NoId,
+    OutOfMemory,
+}
 
 //
 // functions
 //
-
 
 x11_link! { Xft, xft, ["libXft.so.2", "libXft.so"], 77,
     pub fn XftCharExists (_2: *mut Display, _1: *mut XftFont, _0: c_uint) -> c_int,
@@ -116,11 +121,9 @@ variadic:
 globals:
 }
 
-
 //
 // types
 //
-
 
 pub enum XftFontInfo {}
 
@@ -188,11 +191,9 @@ pub struct XftGlyphFontSpec {
 
 pub enum XftPattern {}
 
-
 //
 // constants
 //
-
 
 // font attributes
 pub const XFT_FAMILY: &'static str = "family";

--- a/src/xinerama.rs
+++ b/src/xinerama.rs
@@ -2,25 +2,13 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{
-  c_int,
-  c_short,
-};
+use crate::os_primitives::{c_int, c_short};
 
-use ::xlib::{
-  Bool,
-  Display,
-  Drawable,
-  Status,
-  Window,
-  XID,
-};
-
+use ::xlib::{Bool, Display, Drawable, Status, Window, XID};
 
 //
 // functions
 //
-
 
 x11_link! { Xlib, xinerama, ["libXinerama.so.1", "libXinerama.so"], 10,
   pub fn XineramaIsActive (dpy: *mut Display) -> Bool,
@@ -37,30 +25,28 @@ variadic:
 globals:
 }
 
-
 //
 // types
 //
 
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XineramaScreenInfo {
-  pub screen_number: c_int,
-  pub x_org: c_short,
-  pub y_org: c_short,
-  pub width: c_short,
-  pub height: c_short,
+    pub screen_number: c_int,
+    pub x_org: c_short,
+    pub y_org: c_short,
+    pub width: c_short,
+    pub height: c_short,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XPanoramiXInfo {
-  pub window: Window,
-  pub screen: c_int,
-  pub State: c_int,
-  pub width: c_int,
-  pub height: c_int,
-  pub ScreenCount: c_int,
-  pub eventMask: XID,
+    pub window: Window,
+    pub screen: c_int,
+    pub State: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub ScreenCount: c_int,
+    pub eventMask: XID,
 }

--- a/src/xinput.rs
+++ b/src/xinput.rs
@@ -2,24 +2,9 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{
-  c_char,
-  c_int,
-  c_long,
-  c_short,
-  c_uchar,
-  c_uint,
-  c_ulong,
-};
+use crate::os_primitives::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong};
 
-use ::xlib::{
-  Atom,
-  Display,
-  Time,
-  XEvent,
-  XID,
-  XModifierKeymap,
-};
+use ::xlib::{Atom, Display, Time, XEvent, XModifierKeymap, XID};
 
 //
 // functions
@@ -75,7 +60,6 @@ variadic:
 globals:
 }
 
-
 //
 // types
 //
@@ -87,79 +71,78 @@ pub type XAnyClassPtr = *mut _XAnyClassinfo;
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XDevice {
-  pub device_id: XID,
-  pub num_classes: c_int,
-  pub classes: *mut XInputClassInfo,
+    pub device_id: XID,
+    pub num_classes: c_int,
+    pub classes: *mut XInputClassInfo,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XDeviceControl {
-  pub control: XID,
-  pub length: c_int,
+    pub control: XID,
+    pub length: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XDeviceInfo {
-  pub id: XID,
-  pub type_: Atom,
-  pub name: *mut c_char,
-  pub num_classes: c_int,
-  pub use_: c_int,
-  pub inputclassinfo: XAnyClassPtr,
+    pub id: XID,
+    pub type_: Atom,
+    pub name: *mut c_char,
+    pub num_classes: c_int,
+    pub use_: c_int,
+    pub inputclassinfo: XAnyClassPtr,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XDeviceState {
-  pub device_id: XID,
-  pub num_classes: c_int,
-  pub data: *mut XInputClass,
+    pub device_id: XID,
+    pub num_classes: c_int,
+    pub data: *mut XInputClass,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XDeviceTimeCoord {
-  pub time: Time,
-  pub data: *mut c_int,
+    pub time: Time,
+    pub data: *mut c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XExtensionVersion {
-  pub present: c_int,
-  pub major_version: c_short,
-  pub minor_version: c_short,
+    pub present: c_int,
+    pub major_version: c_short,
+    pub minor_version: c_short,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XFeedbackControl {
-  pub class: XID,
-  pub length: c_int,
-  pub id: XID,
+    pub class: XID,
+    pub length: c_int,
+    pub id: XID,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XFeedbackState {
-  pub class: XID,
-  pub length: c_int,
-  pub id: XID,
+    pub class: XID,
+    pub length: c_int,
+    pub id: XID,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XInputClass {
-  pub class: c_uchar,
-  pub length: c_uchar,
+    pub class: c_uchar,
+    pub length: c_uchar,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XInputClassInfo {
-  pub input_class: c_uchar,
-  pub event_type_base: c_uchar,
+    pub input_class: c_uchar,
+    pub event_type_base: c_uchar,
 }
-

--- a/src/xinput2.rs
+++ b/src/xinput2.rs
@@ -1,6 +1,6 @@
+use crate::os_primitives::{c_double, c_int, c_long, c_uint, c_ulong, c_uchar};
 use xfixes::PointerBarrier;
 use xlib::{Atom, Display, Time, Window};
-use std::os::raw::{c_int, c_uint, c_long, c_double, c_ulong, c_uchar};
 
 //
 // macro translations
@@ -9,15 +9,15 @@ fn mask_byte(mask_flag: i32) -> usize {
     (mask_flag >> 3) as usize
 }
 
-pub fn XISetMask(mask: &mut [::std::os::raw::c_uchar], event: i32) {
+pub fn XISetMask(mask: &mut [c_uchar], event: i32) {
     mask[mask_byte(event)] |= 1 << (event & 7);
 }
 
-pub fn XIClearMask(mask: &mut [::std::os::raw::c_uchar], event: i32) {
+pub fn XIClearMask(mask: &mut [c_uchar], event: i32) {
     mask[mask_byte(event)] &= 1 << (event & 7);
 }
 
-pub fn XIMaskIsSet(mask: &[::std::os::raw::c_uchar], event: i32) -> bool {
+pub fn XIMaskIsSet(mask: &[c_uchar], event: i32) -> bool {
     (mask[mask_byte(event)] & (1 << (event & 7))) != 0
 }
 
@@ -218,59 +218,75 @@ pub const XI_BarrierLeaveMask: i32 = (1 << XI_BarrierLeave);
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIAddMasterInfo {
-    pub _type: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub send_core: ::std::os::raw::c_int,
-    pub enable: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub name: *mut crate::os_primitives::c_char,
+    pub send_core: crate::os_primitives::c_int,
+    pub enable: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XIAddMasterInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIAddMasterInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIAddMasterInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIAddMasterInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIRemoveMasterInfo {
-    pub _type: ::std::os::raw::c_int,
-    pub deviceid: ::std::os::raw::c_int,
-    pub return_mode: ::std::os::raw::c_int,
-    pub return_pointer: ::std::os::raw::c_int,
-    pub return_keyboard: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub deviceid: crate::os_primitives::c_int,
+    pub return_mode: crate::os_primitives::c_int,
+    pub return_pointer: crate::os_primitives::c_int,
+    pub return_keyboard: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XIRemoveMasterInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIRemoveMasterInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIRemoveMasterInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIRemoveMasterInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIAttachSlaveInfo {
-    pub _type: ::std::os::raw::c_int,
-    pub deviceid: ::std::os::raw::c_int,
-    pub new_master: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub deviceid: crate::os_primitives::c_int,
+    pub new_master: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XIAttachSlaveInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIAttachSlaveInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIAttachSlaveInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIAttachSlaveInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIDetachSlaveInfo {
-    pub _type: ::std::os::raw::c_int,
-    pub deviceid: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub deviceid: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XIDetachSlaveInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIDetachSlaveInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIDetachSlaveInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIDetachSlaveInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
@@ -279,47 +295,55 @@ pub struct XIAnyHierarchyChangeInfo {
     pub _bindgen_data_: [u64; 3usize],
 }
 impl XIAnyHierarchyChangeInfo {
-    pub unsafe fn _type(&mut self) -> *mut ::std::os::raw::c_int {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
+    pub unsafe fn _type(&mut self) -> *mut crate::os_primitives::c_int {
+        let raw: *mut u8 = ::core::mem::transmute(&self._bindgen_data_);
+        ::core::mem::transmute(raw.offset(0))
     }
     pub unsafe fn add(&mut self) -> *mut XIAddMasterInfo {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
+        let raw: *mut u8 = ::core::mem::transmute(&self._bindgen_data_);
+        ::core::mem::transmute(raw.offset(0))
     }
     pub unsafe fn remove(&mut self) -> *mut XIRemoveMasterInfo {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
+        let raw: *mut u8 = ::core::mem::transmute(&self._bindgen_data_);
+        ::core::mem::transmute(raw.offset(0))
     }
     pub unsafe fn attach(&mut self) -> *mut XIAttachSlaveInfo {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
+        let raw: *mut u8 = ::core::mem::transmute(&self._bindgen_data_);
+        ::core::mem::transmute(raw.offset(0))
     }
     pub unsafe fn detach(&mut self) -> *mut XIDetachSlaveInfo {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
+        let raw: *mut u8 = ::core::mem::transmute(&self._bindgen_data_);
+        ::core::mem::transmute(raw.offset(0))
     }
 }
-impl ::std::clone::Clone for XIAnyHierarchyChangeInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIAnyHierarchyChangeInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIAnyHierarchyChangeInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIAnyHierarchyChangeInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIModifierState {
-    pub base: ::std::os::raw::c_int,
-    pub latched: ::std::os::raw::c_int,
-    pub locked: ::std::os::raw::c_int,
-    pub effective: ::std::os::raw::c_int,
+    pub base: crate::os_primitives::c_int,
+    pub latched: crate::os_primitives::c_int,
+    pub locked: crate::os_primitives::c_int,
+    pub effective: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XIModifierState {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIModifierState {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIModifierState {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIModifierState {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 pub type XIGroupState = XIModifierState;
@@ -327,354 +351,430 @@ pub type XIGroupState = XIModifierState;
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIButtonState {
-    pub mask_len: ::std::os::raw::c_int,
-    pub mask: *mut ::std::os::raw::c_uchar,
+    pub mask_len: crate::os_primitives::c_int,
+    pub mask: *mut crate::os_primitives::c_uchar,
 }
-impl ::std::clone::Clone for XIButtonState {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIButtonState {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIButtonState {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIButtonState {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIValuatorState {
-    pub mask_len: ::std::os::raw::c_int,
-    pub mask: *mut ::std::os::raw::c_uchar,
-    pub values: *mut ::std::os::raw::c_double,
+    pub mask_len: crate::os_primitives::c_int,
+    pub mask: *mut crate::os_primitives::c_uchar,
+    pub values: *mut crate::os_primitives::c_double,
 }
-impl ::std::clone::Clone for XIValuatorState {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIValuatorState {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIValuatorState {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIValuatorState {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIEventMask {
-    pub deviceid: ::std::os::raw::c_int,
-    pub mask_len: ::std::os::raw::c_int,
-    pub mask: *mut ::std::os::raw::c_uchar,
+    pub deviceid: crate::os_primitives::c_int,
+    pub mask_len: crate::os_primitives::c_int,
+    pub mask: *mut crate::os_primitives::c_uchar,
 }
-impl ::std::clone::Clone for XIEventMask {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIEventMask {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIEventMask {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIEventMask {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIAnyClassInfo {
-    pub _type: ::std::os::raw::c_int,
-    pub sourceid: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub sourceid: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XIAnyClassInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIAnyClassInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIAnyClassInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIAnyClassInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIButtonClassInfo {
-    pub _type: ::std::os::raw::c_int,
-    pub sourceid: ::std::os::raw::c_int,
-    pub num_buttons: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub sourceid: crate::os_primitives::c_int,
+    pub num_buttons: crate::os_primitives::c_int,
     pub labels: *mut Atom,
     pub state: XIButtonState,
 }
-impl ::std::clone::Clone for XIButtonClassInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIButtonClassInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIButtonClassInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIButtonClassInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIKeyClassInfo {
-    pub _type: ::std::os::raw::c_int,
-    pub sourceid: ::std::os::raw::c_int,
-    pub num_keycodes: ::std::os::raw::c_int,
-    pub keycodes: *mut ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub sourceid: crate::os_primitives::c_int,
+    pub num_keycodes: crate::os_primitives::c_int,
+    pub keycodes: *mut crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XIKeyClassInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIKeyClassInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIKeyClassInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIKeyClassInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIValuatorClassInfo {
-    pub _type: ::std::os::raw::c_int,
-    pub sourceid: ::std::os::raw::c_int,
-    pub number: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub sourceid: crate::os_primitives::c_int,
+    pub number: crate::os_primitives::c_int,
     pub label: Atom,
-    pub min: ::std::os::raw::c_double,
-    pub max: ::std::os::raw::c_double,
-    pub value: ::std::os::raw::c_double,
-    pub resolution: ::std::os::raw::c_int,
-    pub mode: ::std::os::raw::c_int,
+    pub min: crate::os_primitives::c_double,
+    pub max: crate::os_primitives::c_double,
+    pub value: crate::os_primitives::c_double,
+    pub resolution: crate::os_primitives::c_int,
+    pub mode: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XIValuatorClassInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIValuatorClassInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIValuatorClassInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIValuatorClassInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIScrollClassInfo {
-    pub _type: ::std::os::raw::c_int,
-    pub sourceid: ::std::os::raw::c_int,
-    pub number: ::std::os::raw::c_int,
-    pub scroll_type: ::std::os::raw::c_int,
-    pub increment: ::std::os::raw::c_double,
-    pub flags: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub sourceid: crate::os_primitives::c_int,
+    pub number: crate::os_primitives::c_int,
+    pub scroll_type: crate::os_primitives::c_int,
+    pub increment: crate::os_primitives::c_double,
+    pub flags: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XIScrollClassInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIScrollClassInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIScrollClassInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIScrollClassInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XITouchClassInfo {
-    pub _type: ::std::os::raw::c_int,
-    pub sourceid: ::std::os::raw::c_int,
-    pub mode: ::std::os::raw::c_int,
-    pub num_touches: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub sourceid: crate::os_primitives::c_int,
+    pub mode: crate::os_primitives::c_int,
+    pub num_touches: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XITouchClassInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XITouchClassInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XITouchClassInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XITouchClassInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIDeviceInfo {
-    pub deviceid: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub _use: ::std::os::raw::c_int,
-    pub attachment: ::std::os::raw::c_int,
-    pub enabled: ::std::os::raw::c_int,
-    pub num_classes: ::std::os::raw::c_int,
+    pub deviceid: crate::os_primitives::c_int,
+    pub name: *mut crate::os_primitives::c_char,
+    pub _use: crate::os_primitives::c_int,
+    pub attachment: crate::os_primitives::c_int,
+    pub enabled: crate::os_primitives::c_int,
+    pub num_classes: crate::os_primitives::c_int,
     pub classes: *mut *mut XIAnyClassInfo,
 }
-impl ::std::clone::Clone for XIDeviceInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIDeviceInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIDeviceInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIDeviceInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIGrabModifiers {
-    pub modifiers: ::std::os::raw::c_int,
-    pub status: ::std::os::raw::c_int,
+    pub modifiers: crate::os_primitives::c_int,
+    pub status: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XIGrabModifiers {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIGrabModifiers {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIGrabModifiers {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIGrabModifiers {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
-pub type BarrierEventID = ::std::os::raw::c_uint;
+pub type BarrierEventID = crate::os_primitives::c_uint;
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIBarrierReleasePointerInfo {
-    pub deviceid: ::std::os::raw::c_int,
+    pub deviceid: crate::os_primitives::c_int,
     pub barrier: PointerBarrier,
     pub eventid: BarrierEventID,
 }
-impl ::std::clone::Clone for XIBarrierReleasePointerInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIBarrierReleasePointerInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIBarrierReleasePointerInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIBarrierReleasePointerInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIEvent {
-    pub _type: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub serial: crate::os_primitives::c_ulong,
+    pub send_event: crate::os_primitives::c_int,
     pub display: *mut Display,
-    pub extension: ::std::os::raw::c_int,
-    pub evtype: ::std::os::raw::c_int,
+    pub extension: crate::os_primitives::c_int,
+    pub evtype: crate::os_primitives::c_int,
     pub time: Time,
 }
-impl ::std::clone::Clone for XIEvent {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIEvent {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIEvent {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIEvent {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIHierarchyInfo {
-    pub deviceid: ::std::os::raw::c_int,
-    pub attachment: ::std::os::raw::c_int,
-    pub _use: ::std::os::raw::c_int,
-    pub enabled: ::std::os::raw::c_int,
-    pub flags: ::std::os::raw::c_int,
+    pub deviceid: crate::os_primitives::c_int,
+    pub attachment: crate::os_primitives::c_int,
+    pub _use: crate::os_primitives::c_int,
+    pub enabled: crate::os_primitives::c_int,
+    pub flags: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XIHierarchyInfo {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIHierarchyInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIHierarchyInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIHierarchyInfo {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIHierarchyEvent {
-    pub _type: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub serial: crate::os_primitives::c_ulong,
+    pub send_event: crate::os_primitives::c_int,
     pub display: *mut Display,
-    pub extension: ::std::os::raw::c_int,
-    pub evtype: ::std::os::raw::c_int,
+    pub extension: crate::os_primitives::c_int,
+    pub evtype: crate::os_primitives::c_int,
     pub time: Time,
-    pub flags: ::std::os::raw::c_int,
-    pub num_info: ::std::os::raw::c_int,
+    pub flags: crate::os_primitives::c_int,
+    pub num_info: crate::os_primitives::c_int,
     pub info: *mut XIHierarchyInfo,
 }
-impl ::std::clone::Clone for XIHierarchyEvent {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIHierarchyEvent {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIHierarchyEvent {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIHierarchyEvent {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIDeviceChangedEvent {
-    pub _type: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub serial: crate::os_primitives::c_ulong,
+    pub send_event: crate::os_primitives::c_int,
     pub display: *mut Display,
-    pub extension: ::std::os::raw::c_int,
-    pub evtype: ::std::os::raw::c_int,
+    pub extension: crate::os_primitives::c_int,
+    pub evtype: crate::os_primitives::c_int,
     pub time: Time,
-    pub deviceid: ::std::os::raw::c_int,
-    pub sourceid: ::std::os::raw::c_int,
-    pub reason: ::std::os::raw::c_int,
-    pub num_classes: ::std::os::raw::c_int,
+    pub deviceid: crate::os_primitives::c_int,
+    pub sourceid: crate::os_primitives::c_int,
+    pub reason: crate::os_primitives::c_int,
+    pub num_classes: crate::os_primitives::c_int,
     pub classes: *mut *mut XIAnyClassInfo,
 }
-impl ::std::clone::Clone for XIDeviceChangedEvent {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIDeviceChangedEvent {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIDeviceChangedEvent {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIDeviceChangedEvent {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIDeviceEvent {
-    pub _type: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub serial: crate::os_primitives::c_ulong,
+    pub send_event: crate::os_primitives::c_int,
     pub display: *mut Display,
-    pub extension: ::std::os::raw::c_int,
-    pub evtype: ::std::os::raw::c_int,
+    pub extension: crate::os_primitives::c_int,
+    pub evtype: crate::os_primitives::c_int,
     pub time: Time,
-    pub deviceid: ::std::os::raw::c_int,
-    pub sourceid: ::std::os::raw::c_int,
-    pub detail: ::std::os::raw::c_int,
+    pub deviceid: crate::os_primitives::c_int,
+    pub sourceid: crate::os_primitives::c_int,
+    pub detail: crate::os_primitives::c_int,
     pub root: Window,
     pub event: Window,
     pub child: Window,
-    pub root_x: ::std::os::raw::c_double,
-    pub root_y: ::std::os::raw::c_double,
-    pub event_x: ::std::os::raw::c_double,
-    pub event_y: ::std::os::raw::c_double,
-    pub flags: ::std::os::raw::c_int,
+    pub root_x: crate::os_primitives::c_double,
+    pub root_y: crate::os_primitives::c_double,
+    pub event_x: crate::os_primitives::c_double,
+    pub event_y: crate::os_primitives::c_double,
+    pub flags: crate::os_primitives::c_int,
     pub buttons: XIButtonState,
     pub valuators: XIValuatorState,
     pub mods: XIModifierState,
     pub group: XIGroupState,
 }
-impl ::std::clone::Clone for XIDeviceEvent {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIDeviceEvent {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIDeviceEvent {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIDeviceEvent {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIRawEvent {
-    pub _type: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub serial: crate::os_primitives::c_ulong,
+    pub send_event: crate::os_primitives::c_int,
     pub display: *mut Display,
-    pub extension: ::std::os::raw::c_int,
-    pub evtype: ::std::os::raw::c_int,
+    pub extension: crate::os_primitives::c_int,
+    pub evtype: crate::os_primitives::c_int,
     pub time: Time,
-    pub deviceid: ::std::os::raw::c_int,
-    pub sourceid: ::std::os::raw::c_int,
-    pub detail: ::std::os::raw::c_int,
-    pub flags: ::std::os::raw::c_int,
+    pub deviceid: crate::os_primitives::c_int,
+    pub sourceid: crate::os_primitives::c_int,
+    pub detail: crate::os_primitives::c_int,
+    pub flags: crate::os_primitives::c_int,
     pub valuators: XIValuatorState,
-    pub raw_values: *mut ::std::os::raw::c_double,
+    pub raw_values: *mut crate::os_primitives::c_double,
 }
-impl ::std::clone::Clone for XIRawEvent {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIRawEvent {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIRawEvent {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIRawEvent {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIEnterEvent {
-    pub _type: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub serial: crate::os_primitives::c_ulong,
+    pub send_event: crate::os_primitives::c_int,
     pub display: *mut Display,
-    pub extension: ::std::os::raw::c_int,
-    pub evtype: ::std::os::raw::c_int,
+    pub extension: crate::os_primitives::c_int,
+    pub evtype: crate::os_primitives::c_int,
     pub time: Time,
-    pub deviceid: ::std::os::raw::c_int,
-    pub sourceid: ::std::os::raw::c_int,
-    pub detail: ::std::os::raw::c_int,
+    pub deviceid: crate::os_primitives::c_int,
+    pub sourceid: crate::os_primitives::c_int,
+    pub detail: crate::os_primitives::c_int,
     pub root: Window,
     pub event: Window,
     pub child: Window,
-    pub root_x: ::std::os::raw::c_double,
-    pub root_y: ::std::os::raw::c_double,
-    pub event_x: ::std::os::raw::c_double,
-    pub event_y: ::std::os::raw::c_double,
-    pub mode: ::std::os::raw::c_int,
-    pub focus: ::std::os::raw::c_int,
-    pub same_screen: ::std::os::raw::c_int,
+    pub root_x: crate::os_primitives::c_double,
+    pub root_y: crate::os_primitives::c_double,
+    pub event_x: crate::os_primitives::c_double,
+    pub event_y: crate::os_primitives::c_double,
+    pub mode: crate::os_primitives::c_int,
+    pub focus: crate::os_primitives::c_int,
+    pub same_screen: crate::os_primitives::c_int,
     pub buttons: XIButtonState,
     pub mods: XIModifierState,
     pub group: XIGroupState,
 }
-impl ::std::clone::Clone for XIEnterEvent {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIEnterEvent {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIEnterEvent {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIEnterEvent {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 pub type XILeaveEvent = XIEnterEvent;
@@ -684,75 +784,87 @@ pub type XIFocusOutEvent = XIEnterEvent;
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIPropertyEvent {
-    pub _type: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub serial: crate::os_primitives::c_ulong,
+    pub send_event: crate::os_primitives::c_int,
     pub display: *mut Display,
-    pub extension: ::std::os::raw::c_int,
-    pub evtype: ::std::os::raw::c_int,
+    pub extension: crate::os_primitives::c_int,
+    pub evtype: crate::os_primitives::c_int,
     pub time: Time,
-    pub deviceid: ::std::os::raw::c_int,
+    pub deviceid: crate::os_primitives::c_int,
     pub property: Atom,
-    pub what: ::std::os::raw::c_int,
+    pub what: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XIPropertyEvent {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIPropertyEvent {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIPropertyEvent {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIPropertyEvent {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XITouchOwnershipEvent {
-    pub _type: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub serial: crate::os_primitives::c_ulong,
+    pub send_event: crate::os_primitives::c_int,
     pub display: *mut Display,
-    pub extension: ::std::os::raw::c_int,
-    pub evtype: ::std::os::raw::c_int,
+    pub extension: crate::os_primitives::c_int,
+    pub evtype: crate::os_primitives::c_int,
     pub time: Time,
-    pub deviceid: ::std::os::raw::c_int,
-    pub sourceid: ::std::os::raw::c_int,
-    pub touchid: ::std::os::raw::c_uint,
+    pub deviceid: crate::os_primitives::c_int,
+    pub sourceid: crate::os_primitives::c_int,
+    pub touchid: crate::os_primitives::c_uint,
     pub root: Window,
     pub event: Window,
     pub child: Window,
-    pub flags: ::std::os::raw::c_int,
+    pub flags: crate::os_primitives::c_int,
 }
-impl ::std::clone::Clone for XITouchOwnershipEvent {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XITouchOwnershipEvent {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XITouchOwnershipEvent {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XITouchOwnershipEvent {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct XIBarrierEvent {
-    pub _type: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub _type: crate::os_primitives::c_int,
+    pub serial: crate::os_primitives::c_ulong,
+    pub send_event: crate::os_primitives::c_int,
     pub display: *mut Display,
-    pub extension: ::std::os::raw::c_int,
-    pub evtype: ::std::os::raw::c_int,
+    pub extension: crate::os_primitives::c_int,
+    pub evtype: crate::os_primitives::c_int,
     pub time: Time,
-    pub deviceid: ::std::os::raw::c_int,
-    pub sourceid: ::std::os::raw::c_int,
+    pub deviceid: crate::os_primitives::c_int,
+    pub sourceid: crate::os_primitives::c_int,
     pub event: Window,
     pub root: Window,
-    pub root_x: ::std::os::raw::c_double,
-    pub root_y: ::std::os::raw::c_double,
-    pub dx: ::std::os::raw::c_double,
-    pub dy: ::std::os::raw::c_double,
-    pub dtime: ::std::os::raw::c_int,
-    pub flags: ::std::os::raw::c_int,
+    pub root_x: crate::os_primitives::c_double,
+    pub root_y: crate::os_primitives::c_double,
+    pub dx: crate::os_primitives::c_double,
+    pub dy: crate::os_primitives::c_double,
+    pub dtime: crate::os_primitives::c_int,
+    pub flags: crate::os_primitives::c_int,
     pub barrier: PointerBarrier,
     pub eventid: BarrierEventID,
 }
-impl ::std::clone::Clone for XIBarrierEvent {
-    fn clone(&self) -> Self { *self }
+impl ::core::clone::Clone for XIBarrierEvent {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
-impl ::std::default::Default for XIBarrierEvent {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+impl ::core::default::Default for XIBarrierEvent {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
+    }
 }

--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -2,41 +2,25 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::slice;
-use std::os::raw::{
-  c_char,
-  c_double,
-  c_int,
-  c_long,
-  c_short,
-  c_schar,
-  c_uchar,
-  c_uint,
-  c_ulong,
-  c_ushort,
-  c_void,
+use core::fmt;
+use crate::os_primitives::{
+    c_char, c_double, c_int, c_long, c_schar, c_short, c_uchar, c_uint, c_ulong, c_ushort, c_void,
 };
-use std::fmt;
+use core::slice;
 
 use libc::wchar_t;
 
-use ::internal::{
-  mem_eq,
-  transmute_union,
-};
+use ::internal::{mem_eq, transmute_union};
 use xf86vmode;
 use xrandr;
 use xss;
 
-
 // deprecated
 pub mod xkb {}
-
 
 //
 // functions
 //
-
 
 x11_link! { Xlib, x11, ["libX11.so.6", "libX11.so"], 767,
   pub fn XActivateScreenSaver (_1: *mut Display) -> c_int,
@@ -810,11 +794,9 @@ variadic:
 globals:
 }
 
-
 //
 // types
 //
-
 
 // common types
 pub type Atom = XID;
@@ -848,44 +830,82 @@ pub enum _XOM {}
 pub enum _XrmHashBucketRec {}
 
 // TODO structs
-#[repr(C)] pub struct _XcmsCCC;
-#[repr(C)] pub struct XcmsColor;
-#[repr(C)] pub struct _XcmsColorSpace;
-#[repr(C)] pub struct _XcmsFunctionSet;
-#[repr(C)] pub struct _XkbAction;
-#[repr(C)] pub struct _XkbBounds;
-#[repr(C)] pub struct _XkbChanges;
-#[repr(C)] pub struct _XkbClientMapRec;
-#[repr(C)] pub struct _XkbColor;
-#[repr(C)] pub struct _XkbComponentList;
-#[repr(C)] pub struct _XkbComponentNames;
-#[repr(C)] pub struct _XkbControls;
-#[repr(C)] pub struct _XkbControlsChanges;
-#[repr(C)] pub struct _XkbControlsNotify;
-#[repr(C)] pub struct _XkbDeviceChanges;
-#[repr(C)] pub struct _XkbDeviceInfo;
-#[repr(C)] pub struct _XkbDeviceLedInfo;
-#[repr(C)] pub struct _XkbDoodad;
-#[repr(C)] pub struct _XkbExtensionDeviceNotify;
-#[repr(C)] pub struct _XkbGeometry;
-#[repr(C)] pub struct _XkbGeometrySizes;
-#[repr(C)] pub struct _XkbIndicatorMapRec;
-#[repr(C)] pub struct _XkbKey;
-#[repr(C)] pub struct _XkbKeyType;
-#[repr(C)] pub struct _XkbMapChanges;
-#[repr(C)] pub struct _XkbMods;
-#[repr(C)] pub struct _XkbNameChanges;
-#[repr(C)] pub struct _XkbNamesNotify;
-#[repr(C)] pub struct _XkbOutline;
-#[repr(C)] pub struct _XkbOverlay;
-#[repr(C)] pub struct _XkbOverlayKey;
-#[repr(C)] pub struct _XkbOverlayRow;
-#[repr(C)] pub struct _XkbProperty;
-#[repr(C)] pub struct _XkbRow;
-#[repr(C)] pub struct _XkbSection;
-#[repr(C)] pub struct _XkbServerMapRec;
-#[repr(C)] pub struct _XkbShape;
-#[repr(C)] pub struct _XkbSymInterpretRec;
+#[repr(C)]
+pub struct _XcmsCCC;
+#[repr(C)]
+pub struct XcmsColor;
+#[repr(C)]
+pub struct _XcmsColorSpace;
+#[repr(C)]
+pub struct _XcmsFunctionSet;
+#[repr(C)]
+pub struct _XkbAction;
+#[repr(C)]
+pub struct _XkbBounds;
+#[repr(C)]
+pub struct _XkbChanges;
+#[repr(C)]
+pub struct _XkbClientMapRec;
+#[repr(C)]
+pub struct _XkbColor;
+#[repr(C)]
+pub struct _XkbComponentList;
+#[repr(C)]
+pub struct _XkbComponentNames;
+#[repr(C)]
+pub struct _XkbControls;
+#[repr(C)]
+pub struct _XkbControlsChanges;
+#[repr(C)]
+pub struct _XkbControlsNotify;
+#[repr(C)]
+pub struct _XkbDeviceChanges;
+#[repr(C)]
+pub struct _XkbDeviceInfo;
+#[repr(C)]
+pub struct _XkbDeviceLedInfo;
+#[repr(C)]
+pub struct _XkbDoodad;
+#[repr(C)]
+pub struct _XkbExtensionDeviceNotify;
+#[repr(C)]
+pub struct _XkbGeometry;
+#[repr(C)]
+pub struct _XkbGeometrySizes;
+#[repr(C)]
+pub struct _XkbIndicatorMapRec;
+#[repr(C)]
+pub struct _XkbKey;
+#[repr(C)]
+pub struct _XkbKeyType;
+#[repr(C)]
+pub struct _XkbMapChanges;
+#[repr(C)]
+pub struct _XkbMods;
+#[repr(C)]
+pub struct _XkbNameChanges;
+#[repr(C)]
+pub struct _XkbNamesNotify;
+#[repr(C)]
+pub struct _XkbOutline;
+#[repr(C)]
+pub struct _XkbOverlay;
+#[repr(C)]
+pub struct _XkbOverlayKey;
+#[repr(C)]
+pub struct _XkbOverlayRow;
+#[repr(C)]
+pub struct _XkbProperty;
+#[repr(C)]
+pub struct _XkbRow;
+#[repr(C)]
+pub struct _XkbSection;
+#[repr(C)]
+pub struct _XkbServerMapRec;
+#[repr(C)]
+pub struct _XkbShape;
+#[repr(C)]
+pub struct _XkbSymInterpretRec;
 
 // union placeholders
 pub type XEDataObject = *mut c_void;
@@ -950,9 +970,10 @@ pub type XrmDatabase = *mut _XrmHashBucketRec;
 pub type XrmOptionDescList = *mut XrmOptionDescRec;
 
 // function pointers
-pub type XConnectionWatchProc = Option<unsafe extern "C" fn (*mut Display, XPointer, c_int, Bool, XPointer)>;
-pub type XIMProc = Option<unsafe extern "C" fn (XIM, XPointer, XPointer)>;
-pub type XICProc = Option<unsafe extern "C" fn (XIC, XPointer, XPointer) -> Bool>;
+pub type XConnectionWatchProc =
+    Option<unsafe extern "C" fn(*mut Display, XPointer, c_int, Bool, XPointer)>;
+pub type XIMProc = Option<unsafe extern "C" fn(XIM, XPointer, XPointer)>;
+pub type XICProc = Option<unsafe extern "C" fn(XIC, XPointer, XPointer) -> Bool>;
 
 // C enums
 pub type XICCEncodingStyle = c_int;
@@ -964,124 +985,121 @@ pub type XrmOptionKind = c_int;
 #[cfg(test)]
 #[repr(C)]
 enum TestEnum {
-  Variant1,
-  Variant2,
+    Variant1,
+    Variant2,
 }
 
 #[test]
-fn enum_size_test () {
-  assert!(::std::mem::size_of::<TestEnum>() == ::std::mem::size_of::<c_int>());
+fn enum_size_test() {
+    assert!(::std::mem::size_of::<TestEnum>() == ::std::mem::size_of::<c_int>());
 }
-
 
 //
 // event structures
 //
 
-
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub union XEvent {
-  pub type_: c_int,
-  pub any: XAnyEvent,
-  pub button: XButtonEvent,
-  pub circulate: XCirculateEvent,
-  pub circulate_request: XCirculateRequestEvent,
-  pub client_message: XClientMessageEvent,
-  pub colormap: XColormapEvent,
-  pub configure: XConfigureEvent,
-  pub configure_request: XConfigureRequestEvent,
-  pub create_window: XCreateWindowEvent,
-  pub crossing: XCrossingEvent,
-  pub destroy_window: XDestroyWindowEvent,
-  pub error: XErrorEvent,
-  pub expose: XExposeEvent,
-  pub focus_change: XFocusChangeEvent,
-  pub generic_event_cookie: XGenericEventCookie,
-  pub graphics_expose: XGraphicsExposeEvent,
-  pub gravity: XGravityEvent,
-  pub key: XKeyEvent,
-  pub keymap: XKeymapEvent,
-  pub map: XMapEvent,
-  pub mapping: XMappingEvent,
-  pub map_request: XMapRequestEvent,
-  pub motion: XMotionEvent,
-  pub no_expose: XNoExposeEvent,
-  pub property: XPropertyEvent,
-  pub reparent: XReparentEvent,
-  pub resize_request: XResizeRequestEvent,
-  pub selection_clear: XSelectionClearEvent,
-  pub selection: XSelectionEvent,
-  pub selection_request: XSelectionRequestEvent,
-  pub unmap: XUnmapEvent,
-  pub visibility: XVisibilityEvent,
-  pub pad: [c_long; 24],
-  // xf86vidmode
-  pub xf86vm_notify: xf86vmode::XF86VidModeNotifyEvent,
-  // xrandr
-  pub xrr_screen_change_notify: xrandr::XRRScreenChangeNotifyEvent,
-  pub xrr_notify: xrandr::XRRNotifyEvent,
-  pub xrr_output_change_notify: xrandr::XRROutputChangeNotifyEvent,
-  pub xrr_crtc_change_notify: xrandr::XRRCrtcChangeNotifyEvent,
-  pub xrr_output_property_notify: xrandr::XRROutputPropertyNotifyEvent,
-  pub xrr_provider_change_notify: xrandr::XRRProviderChangeNotifyEvent,
-  pub xrr_provider_property_notify: xrandr::XRRProviderPropertyNotifyEvent,
-  pub xrr_resource_change_notify: xrandr::XRRResourceChangeNotifyEvent,
-  // xscreensaver
-  pub xss_notify: xss::XScreenSaverNotifyEvent,
+    pub type_: c_int,
+    pub any: XAnyEvent,
+    pub button: XButtonEvent,
+    pub circulate: XCirculateEvent,
+    pub circulate_request: XCirculateRequestEvent,
+    pub client_message: XClientMessageEvent,
+    pub colormap: XColormapEvent,
+    pub configure: XConfigureEvent,
+    pub configure_request: XConfigureRequestEvent,
+    pub create_window: XCreateWindowEvent,
+    pub crossing: XCrossingEvent,
+    pub destroy_window: XDestroyWindowEvent,
+    pub error: XErrorEvent,
+    pub expose: XExposeEvent,
+    pub focus_change: XFocusChangeEvent,
+    pub generic_event_cookie: XGenericEventCookie,
+    pub graphics_expose: XGraphicsExposeEvent,
+    pub gravity: XGravityEvent,
+    pub key: XKeyEvent,
+    pub keymap: XKeymapEvent,
+    pub map: XMapEvent,
+    pub mapping: XMappingEvent,
+    pub map_request: XMapRequestEvent,
+    pub motion: XMotionEvent,
+    pub no_expose: XNoExposeEvent,
+    pub property: XPropertyEvent,
+    pub reparent: XReparentEvent,
+    pub resize_request: XResizeRequestEvent,
+    pub selection_clear: XSelectionClearEvent,
+    pub selection: XSelectionEvent,
+    pub selection_request: XSelectionRequestEvent,
+    pub unmap: XUnmapEvent,
+    pub visibility: XVisibilityEvent,
+    pub pad: [c_long; 24],
+    // xf86vidmode
+    pub xf86vm_notify: xf86vmode::XF86VidModeNotifyEvent,
+    // xrandr
+    pub xrr_screen_change_notify: xrandr::XRRScreenChangeNotifyEvent,
+    pub xrr_notify: xrandr::XRRNotifyEvent,
+    pub xrr_output_change_notify: xrandr::XRROutputChangeNotifyEvent,
+    pub xrr_crtc_change_notify: xrandr::XRRCrtcChangeNotifyEvent,
+    pub xrr_output_property_notify: xrandr::XRROutputPropertyNotifyEvent,
+    pub xrr_provider_change_notify: xrandr::XRRProviderChangeNotifyEvent,
+    pub xrr_provider_property_notify: xrandr::XRRProviderPropertyNotifyEvent,
+    pub xrr_resource_change_notify: xrandr::XRRResourceChangeNotifyEvent,
+    // xscreensaver
+    pub xss_notify: xss::XScreenSaverNotifyEvent,
 }
 
 impl XEvent {
-  pub fn get_type (&self) -> c_int {
-    unsafe {
-      self.type_
+    pub fn get_type(&self) -> c_int {
+        unsafe { self.type_ }
     }
-  }
 }
 
 impl fmt::Debug for XEvent {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    let mut d = f.debug_struct("XEvent");
-    unsafe {
-      match self.type_ {
-        KeyPress => d.field("key", &self.key),
-        KeyRelease => d.field("key", &self.key),
-        ButtonPress => d.field("button", &self.button),
-        ButtonRelease => d.field("button", &self.button),
-        MotionNotify => d.field("motion", &self.motion),
-        EnterNotify => d.field("crossing", &self.crossing),
-        LeaveNotify => d.field("crossing", &self.crossing),
-        FocusIn => d.field("focus_change", &self.focus_change),
-        FocusOut => d.field("focus_change", &self.focus_change),
-        KeymapNotify => d.field("keymap", &self.keymap),
-        Expose => d.field("expose", &self.expose),
-        GraphicsExpose => d.field("graphics_expose", &self.graphics_expose),
-        NoExpose => d.field("no_expose", &self.no_expose),
-        VisibilityNotify => d.field("visibility", &self.visibility),
-        CreateNotify => d.field("create_window", &self.create_window),
-        DestroyNotify => d.field("destroy_window", &self.destroy_window),
-        UnmapNotify => d.field("unmap", &self.unmap),
-        MapNotify => d.field("map", &self.map),
-        MapRequest => d.field("map_request", &self.map_request),
-        ReparentNotify => d.field("reparent", &self.reparent),
-        ConfigureNotify => d.field("configure", &self.configure),
-        ConfigureRequest => d.field("configure_request", &self.configure_request),
-        GravityNotify => d.field("gravity", &self.gravity),
-        ResizeRequest => d.field("resize_request", &self.resize_request),
-        CirculateNotify => d.field("circulate", &self.circulate),
-        CirculateRequest => d.field("circulate_request", &self.circulate_request),
-        PropertyNotify => d.field("property", &self.property),
-        SelectionClear => d.field("selection_clear", &self.selection_clear),
-        SelectionRequest => d.field("selection_request", &self.selection_request),
-        SelectionNotify => d.field("selection", &self.selection),
-        ColormapNotify => d.field("colormap", &self.colormap),
-        ClientMessage => d.field("client_message", &self.client_message),
-        MappingNotify => d.field("mapping", &self.mapping),
-        GenericEvent => d.field("generic_event_cookie", &self.generic_event_cookie),
-        _ => d.field("any", &self.any),
-      }
-    }.finish()
-  }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut d = f.debug_struct("XEvent");
+        unsafe {
+            match self.type_ {
+                KeyPress => d.field("key", &self.key),
+                KeyRelease => d.field("key", &self.key),
+                ButtonPress => d.field("button", &self.button),
+                ButtonRelease => d.field("button", &self.button),
+                MotionNotify => d.field("motion", &self.motion),
+                EnterNotify => d.field("crossing", &self.crossing),
+                LeaveNotify => d.field("crossing", &self.crossing),
+                FocusIn => d.field("focus_change", &self.focus_change),
+                FocusOut => d.field("focus_change", &self.focus_change),
+                KeymapNotify => d.field("keymap", &self.keymap),
+                Expose => d.field("expose", &self.expose),
+                GraphicsExpose => d.field("graphics_expose", &self.graphics_expose),
+                NoExpose => d.field("no_expose", &self.no_expose),
+                VisibilityNotify => d.field("visibility", &self.visibility),
+                CreateNotify => d.field("create_window", &self.create_window),
+                DestroyNotify => d.field("destroy_window", &self.destroy_window),
+                UnmapNotify => d.field("unmap", &self.unmap),
+                MapNotify => d.field("map", &self.map),
+                MapRequest => d.field("map_request", &self.map_request),
+                ReparentNotify => d.field("reparent", &self.reparent),
+                ConfigureNotify => d.field("configure", &self.configure),
+                ConfigureRequest => d.field("configure_request", &self.configure_request),
+                GravityNotify => d.field("gravity", &self.gravity),
+                ResizeRequest => d.field("resize_request", &self.resize_request),
+                CirculateNotify => d.field("circulate", &self.circulate),
+                CirculateRequest => d.field("circulate_request", &self.circulate_request),
+                PropertyNotify => d.field("property", &self.property),
+                SelectionClear => d.field("selection_clear", &self.selection_clear),
+                SelectionRequest => d.field("selection_request", &self.selection_request),
+                SelectionNotify => d.field("selection", &self.selection),
+                ColormapNotify => d.field("colormap", &self.colormap),
+                ClientMessage => d.field("client_message", &self.client_message),
+                MappingNotify => d.field("mapping", &self.mapping),
+                GenericEvent => d.field("generic_event_cookie", &self.generic_event_cookie),
+                _ => d.field("any", &self.any),
+            }
+        }
+        .finish()
+    }
 }
 
 macro_rules! event_conversions_and_tests {
@@ -1171,31 +1189,31 @@ event_conversions_and_tests! {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XAnyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XButtonEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub root: Window,
-  pub subwindow: Window,
-  pub time: Time,
-  pub x: c_int,
-  pub y: c_int,
-  pub x_root: c_int,
-  pub y_root: c_int,
-  pub state: c_uint,
-  pub button: c_uint,
-  pub same_screen: Bool,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub root: Window,
+    pub subwindow: Window,
+    pub time: Time,
+    pub x: c_int,
+    pub y: c_int,
+    pub x_root: c_int,
+    pub y_root: c_int,
+    pub state: c_uint,
+    pub button: c_uint,
+    pub same_screen: Bool,
 }
 pub type XButtonPressedEvent = XButtonEvent;
 pub type XButtonReleasedEvent = XButtonEvent;
@@ -1203,127 +1221,127 @@ pub type XButtonReleasedEvent = XButtonEvent;
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XCirculateEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub event: Window,
-  pub window: Window,
-  pub place: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub event: Window,
+    pub window: Window,
+    pub place: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XCirculateRequestEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub parent: Window,
-  pub window: Window,
-  pub place: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub parent: Window,
+    pub window: Window,
+    pub place: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XClientMessageEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub message_type: Atom,
-  pub format: c_int,
-  pub data: ClientMessageData,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub message_type: Atom,
+    pub format: c_int,
+    pub data: ClientMessageData,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XColormapEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub colormap: Colormap,
-  pub new: Bool,
-  pub state: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub colormap: Colormap,
+    pub new: Bool,
+    pub state: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XConfigureEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub event: Window,
-  pub window: Window,
-  pub x: c_int,
-  pub y: c_int,
-  pub width: c_int,
-  pub height: c_int,
-  pub border_width: c_int,
-  pub above: Window,
-  pub override_redirect: Bool,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub event: Window,
+    pub window: Window,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub border_width: c_int,
+    pub above: Window,
+    pub override_redirect: Bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XConfigureRequestEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub parent: Window,
-  pub window: Window,
-  pub x: c_int,
-  pub y: c_int,
-  pub width: c_int,
-  pub height: c_int,
-  pub border_width: c_int,
-  pub above: Window,
-  pub detail: c_int,
-  pub value_mask: c_ulong,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub parent: Window,
+    pub window: Window,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub border_width: c_int,
+    pub above: Window,
+    pub detail: c_int,
+    pub value_mask: c_ulong,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XCreateWindowEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub parent: Window,
-  pub window: Window,
-  pub x: c_int,
-  pub y: c_int,
-  pub width: c_int,
-  pub height: c_int,
-  pub border_width: c_int,
-  pub override_redirect: Bool,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub parent: Window,
+    pub window: Window,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub border_width: c_int,
+    pub override_redirect: Bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XCrossingEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub root: Window,
-  pub subwindow: Window,
-  pub time: Time,
-  pub x: c_int,
-  pub y: c_int,
-  pub x_root: c_int,
-  pub y_root: c_int,
-  pub mode: c_int,
-  pub detail: c_int,
-  pub same_screen: Bool,
-  pub focus: Bool,
-  pub state: c_uint,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub root: Window,
+    pub subwindow: Window,
+    pub time: Time,
+    pub x: c_int,
+    pub y: c_int,
+    pub x_root: c_int,
+    pub y_root: c_int,
+    pub mode: c_int,
+    pub detail: c_int,
+    pub same_screen: Bool,
+    pub focus: Bool,
+    pub state: c_uint,
 }
 pub type XEnterWindowEvent = XCrossingEvent;
 pub type XLeaveWindowEvent = XCrossingEvent;
@@ -1331,51 +1349,51 @@ pub type XLeaveWindowEvent = XCrossingEvent;
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XDestroyWindowEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub event: Window,
-  pub window: Window,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub event: Window,
+    pub window: Window,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XErrorEvent {
-  pub type_: c_int,
-  pub display: *mut Display,
-  pub resourceid: XID,
-  pub serial: c_ulong,
-  pub error_code: c_uchar,
-  pub request_code: c_uchar,
-  pub minor_code: c_uchar,
+    pub type_: c_int,
+    pub display: *mut Display,
+    pub resourceid: XID,
+    pub serial: c_ulong,
+    pub error_code: c_uchar,
+    pub request_code: c_uchar,
+    pub minor_code: c_uchar,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XExposeEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub x: c_int,
-  pub y: c_int,
-  pub width: c_int,
-  pub height: c_int,
-  pub count: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub count: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XFocusChangeEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub mode: c_int,
-  pub detail: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub mode: c_int,
+    pub detail: c_int,
 }
 pub type XFocusInEvent = XFocusChangeEvent;
 pub type XFocusOutEvent = XFocusChangeEvent;
@@ -1383,51 +1401,51 @@ pub type XFocusOutEvent = XFocusChangeEvent;
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XGraphicsExposeEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub drawable: Drawable,
-  pub x: c_int,
-  pub y: c_int,
-  pub width: c_int,
-  pub height: c_int,
-  pub count: c_int,
-  pub major_code: c_int,
-  pub minor_code: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub drawable: Drawable,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub count: c_int,
+    pub major_code: c_int,
+    pub minor_code: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XGravityEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub event: Window,
-  pub window: Window,
-  pub x: c_int,
-  pub y: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub event: Window,
+    pub window: Window,
+    pub x: c_int,
+    pub y: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XKeyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub root: Window,
-  pub subwindow: Window,
-  pub time: Time,
-  pub x: c_int,
-  pub y: c_int,
-  pub x_root: c_int,
-  pub y_root: c_int,
-  pub state: c_uint,
-  pub keycode: c_uint,
-  pub same_screen: Bool,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub root: Window,
+    pub subwindow: Window,
+    pub time: Time,
+    pub x: c_int,
+    pub y: c_int,
+    pub x_root: c_int,
+    pub y_root: c_int,
+    pub state: c_uint,
+    pub keycode: c_uint,
+    pub same_screen: Bool,
 }
 pub type XKeyPressedEvent = XKeyEvent;
 pub type XKeyReleasedEvent = XKeyEvent;
@@ -1435,529 +1453,525 @@ pub type XKeyReleasedEvent = XKeyEvent;
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XKeymapEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub key_vector: [c_char; 32],
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub key_vector: [c_char; 32],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XMapEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub event: Window,
-  pub window: Window,
-  pub override_redirect: Bool,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub event: Window,
+    pub window: Window,
+    pub override_redirect: Bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XMappingEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub event: Window,
-  pub request: c_int,
-  pub first_keycode: c_int,
-  pub count: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub event: Window,
+    pub request: c_int,
+    pub first_keycode: c_int,
+    pub count: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XMapRequestEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub parent: Window,
-  pub window: Window,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub parent: Window,
+    pub window: Window,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XMotionEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub root: Window,
-  pub subwindow: Window,
-  pub time: Time,
-  pub x: c_int,
-  pub y: c_int,
-  pub x_root: c_int,
-  pub y_root: c_int,
-  pub state: c_uint,
-  pub is_hint: c_char,
-  pub same_screen: Bool,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub root: Window,
+    pub subwindow: Window,
+    pub time: Time,
+    pub x: c_int,
+    pub y: c_int,
+    pub x_root: c_int,
+    pub y_root: c_int,
+    pub state: c_uint,
+    pub is_hint: c_char,
+    pub same_screen: Bool,
 }
 pub type XPointerMovedEvent = XMotionEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XNoExposeEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub drawable: Drawable,
-  pub major_code: c_int,
-  pub minor_code: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub drawable: Drawable,
+    pub major_code: c_int,
+    pub minor_code: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XPropertyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub atom: Atom,
-  pub time: Time,
-  pub state: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub atom: Atom,
+    pub time: Time,
+    pub state: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XReparentEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub event: Window,
-  pub window: Window,
-  pub parent: Window,
-  pub x: c_int,
-  pub y: c_int,
-  pub override_redirect: Bool,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub event: Window,
+    pub window: Window,
+    pub parent: Window,
+    pub x: c_int,
+    pub y: c_int,
+    pub override_redirect: Bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XResizeRequestEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub width: c_int,
-  pub height: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub width: c_int,
+    pub height: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XSelectionClearEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub selection: Atom,
-  pub time: Time,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub selection: Atom,
+    pub time: Time,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XSelectionEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub requestor: Window,
-  pub selection: Atom,
-  pub target: Atom,
-  pub property: Atom,
-  pub time: Time,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub requestor: Window,
+    pub selection: Atom,
+    pub target: Atom,
+    pub property: Atom,
+    pub time: Time,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XSelectionRequestEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub owner: Window,
-  pub requestor: Window,
-  pub selection: Atom,
-  pub target: Atom,
-  pub property: Atom,
-  pub time: Time,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub owner: Window,
+    pub requestor: Window,
+    pub selection: Atom,
+    pub target: Atom,
+    pub property: Atom,
+    pub time: Time,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XUnmapEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub event: Window,
-  pub window: Window,
-  pub from_configure: Bool,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub event: Window,
+    pub window: Window,
+    pub from_configure: Bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XVisibilityEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub state: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub state: c_int,
 }
-
 
 //
 // Xkb structs
 //
 
-
 #[repr(C)]
 pub struct _XkbCompatMapRec {
-  pub sym_interpret: XkbSymInterpretPtr,
-  pub groups: [XkbModsRec; XkbNumKbdGroups],
-  pub num_si: c_ushort,
-  pub size_si: c_ushort,
+    pub sym_interpret: XkbSymInterpretPtr,
+    pub groups: [XkbModsRec; XkbNumKbdGroups],
+    pub num_si: c_ushort,
+    pub size_si: c_ushort,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XkbDesc {
-  pub dpy: *mut Display,
-  pub flags: c_ushort,
-  pub device_spec: c_ushort,
-  pub min_key_code: KeyCode,
-  pub max_key_code: KeyCode,
-  pub ctrls: XkbControlsPtr,
-  pub server: XkbServerMapPtr,
-  pub map: XkbClientMapPtr,
-  pub indicators: XkbIndicatorPtr,
-  pub names: XkbNamesPtr,
-  pub compat: XkbCompatMapPtr,
-  pub geom: XkbGeometryPtr,
+    pub dpy: *mut Display,
+    pub flags: c_ushort,
+    pub device_spec: c_ushort,
+    pub min_key_code: KeyCode,
+    pub max_key_code: KeyCode,
+    pub ctrls: XkbControlsPtr,
+    pub server: XkbServerMapPtr,
+    pub map: XkbClientMapPtr,
+    pub indicators: XkbIndicatorPtr,
+    pub names: XkbNamesPtr,
+    pub compat: XkbCompatMapPtr,
+    pub geom: XkbGeometryPtr,
 }
 
 #[repr(C)]
 pub struct _XkbIndicatorRec {
-  pub phys_indicators: c_ulong,
-  pub maps: [XkbIndicatorMapRec; XkbNumIndicators],
+    pub phys_indicators: c_ulong,
+    pub maps: [XkbIndicatorMapRec; XkbNumIndicators],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XkbKeyAliasRec {
-  pub real: [c_char; XkbKeyNameLength],
-  pub alias: [c_char; XkbKeyNameLength],
+    pub real: [c_char; XkbKeyNameLength],
+    pub alias: [c_char; XkbKeyNameLength],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XkbKeyNameRec {
-  pub name: [c_char; XkbKeyNameLength],
+    pub name: [c_char; XkbKeyNameLength],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XkbNamesRec {
-  pub keycodes: Atom,
-  pub geometry: Atom,
-  pub symbols: Atom,
-  pub types: Atom,
-  pub compat: Atom,
-  pub vmods: [Atom; XkbNumVirtualMods],
-  pub indicators: [Atom; XkbNumIndicators],
-  pub groups: [Atom; XkbNumKbdGroups],
-  pub keys: XkbKeyNamePtr,
-  pub key_aliases: XkbKeyAliasPtr,
-  pub radio_groups: *mut Atom,
-  pub phys_symbols: Atom,
-  pub num_keys: c_uchar,
-  pub num_key_aliases: c_uchar,
-  pub num_rg: c_ushort,
+    pub keycodes: Atom,
+    pub geometry: Atom,
+    pub symbols: Atom,
+    pub types: Atom,
+    pub compat: Atom,
+    pub vmods: [Atom; XkbNumVirtualMods],
+    pub indicators: [Atom; XkbNumIndicators],
+    pub groups: [Atom; XkbNumKbdGroups],
+    pub keys: XkbKeyNamePtr,
+    pub key_aliases: XkbKeyAliasPtr,
+    pub radio_groups: *mut Atom,
+    pub phys_symbols: Atom,
+    pub num_keys: c_uchar,
+    pub num_key_aliases: c_uchar,
+    pub num_rg: c_ushort,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XkbStateRec {
-  pub group: c_uchar,
-  pub locked_group: c_uchar,
-  pub base_group: c_ushort,
-  pub latched_group: c_ushort,
-  pub mods: c_uchar,
-  pub base_mods: c_uchar,
-  pub latched_mods: c_uchar,
-  pub locked_mods: c_uchar,
-  pub compat_state: c_uchar,
-  pub grab_mods: c_uchar,
-  pub compat_grab_mods: c_uchar,
-  pub lookup_mods: c_uchar,
-  pub compat_lookup_mods: c_uchar,
-  pub ptr_buttons: c_ushort,
+    pub group: c_uchar,
+    pub locked_group: c_uchar,
+    pub base_group: c_ushort,
+    pub latched_group: c_ushort,
+    pub mods: c_uchar,
+    pub base_mods: c_uchar,
+    pub latched_mods: c_uchar,
+    pub locked_mods: c_uchar,
+    pub compat_state: c_uchar,
+    pub grab_mods: c_uchar,
+    pub compat_grab_mods: c_uchar,
+    pub lookup_mods: c_uchar,
+    pub compat_lookup_mods: c_uchar,
+    pub ptr_buttons: c_ushort,
 }
-
 
 //
 // Xkb event structs
 //
 
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XkbAnyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub time: Time,
-  pub xkb_type: c_int,
-  pub device: c_uint,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub time: Time,
+    pub xkb_type: c_int,
+    pub device: c_uint,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XkbNewKeyboardNotifyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub time: Time,
-  pub xkb_type: c_int,
-  pub device: c_int,
-  pub old_device: c_int,
-  pub min_key_code: c_int,
-  pub max_key_code: c_int,
-  pub old_min_key_code: c_int,
-  pub old_max_key_code: c_int,
-  pub changed: c_uint,
-  pub req_major: c_char,
-  pub req_minor: c_char,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub time: Time,
+    pub xkb_type: c_int,
+    pub device: c_int,
+    pub old_device: c_int,
+    pub min_key_code: c_int,
+    pub max_key_code: c_int,
+    pub old_min_key_code: c_int,
+    pub old_max_key_code: c_int,
+    pub changed: c_uint,
+    pub req_major: c_char,
+    pub req_minor: c_char,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XkbMapNotifyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub time: Time,
-  pub xkb_type: c_int,
-  pub device: c_int,
-  pub changed: c_uint,
-  pub flags: c_uint,
-  pub first_type: c_int,
-  pub num_types: c_int,
-  pub min_key_code: KeyCode,
-  pub max_key_code: KeyCode,
-  pub first_key_sym: KeyCode,
-  pub first_key_act: KeyCode,
-  pub first_key_bahavior: KeyCode,
-  pub first_key_explicit: KeyCode,
-  pub first_modmap_key: KeyCode,
-  pub first_vmodmap_key: KeyCode,
-  pub num_key_syms: c_int,
-  pub num_key_acts: c_int,
-  pub num_key_behaviors: c_int,
-  pub num_key_explicit: c_int,
-  pub num_modmap_keys: c_int,
-  pub num_vmodmap_keys: c_int,
-  pub vmods: c_uint,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub time: Time,
+    pub xkb_type: c_int,
+    pub device: c_int,
+    pub changed: c_uint,
+    pub flags: c_uint,
+    pub first_type: c_int,
+    pub num_types: c_int,
+    pub min_key_code: KeyCode,
+    pub max_key_code: KeyCode,
+    pub first_key_sym: KeyCode,
+    pub first_key_act: KeyCode,
+    pub first_key_bahavior: KeyCode,
+    pub first_key_explicit: KeyCode,
+    pub first_modmap_key: KeyCode,
+    pub first_vmodmap_key: KeyCode,
+    pub num_key_syms: c_int,
+    pub num_key_acts: c_int,
+    pub num_key_behaviors: c_int,
+    pub num_key_explicit: c_int,
+    pub num_modmap_keys: c_int,
+    pub num_vmodmap_keys: c_int,
+    pub vmods: c_uint,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XkbStateNotifyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub time: Time,
-  pub xkb_type: c_int,
-  pub device: c_int,
-  pub changed: c_uint,
-  pub group: c_int,
-  pub base_group: c_int,
-  pub latched_group: c_int,
-  pub locked_group: c_int,
-  pub mods: c_uint,
-  pub base_mods: c_uint,
-  pub latched_mods: c_uint,
-  pub locked_mods: c_uint,
-  pub compat_state: c_int,
-  pub grab_mods: c_uchar,
-  pub compat_grab_mods: c_uchar,
-  pub lookup_mods: c_uchar,
-  pub compat_lookup_mods: c_uchar,
-  pub ptr_buttons: c_int,
-  pub keycode: KeyCode,
-  pub event_type: c_char,
-  pub req_major: c_char,
-  pub req_minor: c_char,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub time: Time,
+    pub xkb_type: c_int,
+    pub device: c_int,
+    pub changed: c_uint,
+    pub group: c_int,
+    pub base_group: c_int,
+    pub latched_group: c_int,
+    pub locked_group: c_int,
+    pub mods: c_uint,
+    pub base_mods: c_uint,
+    pub latched_mods: c_uint,
+    pub locked_mods: c_uint,
+    pub compat_state: c_int,
+    pub grab_mods: c_uchar,
+    pub compat_grab_mods: c_uchar,
+    pub lookup_mods: c_uchar,
+    pub compat_lookup_mods: c_uchar,
+    pub ptr_buttons: c_int,
+    pub keycode: KeyCode,
+    pub event_type: c_char,
+    pub req_major: c_char,
+    pub req_minor: c_char,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XkbControlsNotifyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub time: Time,
-  pub xkb_type: c_int,
-  pub device: c_int,
-  pub changed_ctrls: c_uint,
-  pub enabled_ctrls: c_uint,
-  pub enabled_ctrl_changes: c_uint,
-  pub num_groups: c_int,
-  pub keycode: KeyCode,
-  pub event_type: c_char,
-  pub req_major: c_char,
-  pub req_minor: c_char,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub time: Time,
+    pub xkb_type: c_int,
+    pub device: c_int,
+    pub changed_ctrls: c_uint,
+    pub enabled_ctrls: c_uint,
+    pub enabled_ctrl_changes: c_uint,
+    pub num_groups: c_int,
+    pub keycode: KeyCode,
+    pub event_type: c_char,
+    pub req_major: c_char,
+    pub req_minor: c_char,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XkbIndicatorNotifyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub time: Time,
-  pub xkb_type: c_int,
-  pub device: c_int,
-  pub changed: c_uint,
-  pub state: c_uint,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub time: Time,
+    pub xkb_type: c_int,
+    pub device: c_int,
+    pub changed: c_uint,
+    pub state: c_uint,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XkbNamesNotifyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub time: Time,
-  pub xkb_type: c_int,
-  pub device: c_int,
-  pub changed: c_uint,
-  pub first_type: c_int,
-  pub num_types: c_int,
-  pub first_lvl: c_int,
-  pub num_lvls: c_int,
-  pub num_aliases: c_int,
-  pub num_radio_groups: c_int,
-  pub changed_vmods: c_uint,
-  pub changed_groups: c_uint,
-  pub changed_indicators: c_uint,
-  pub first_key: c_int,
-  pub num_keys: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub time: Time,
+    pub xkb_type: c_int,
+    pub device: c_int,
+    pub changed: c_uint,
+    pub first_type: c_int,
+    pub num_types: c_int,
+    pub first_lvl: c_int,
+    pub num_lvls: c_int,
+    pub num_aliases: c_int,
+    pub num_radio_groups: c_int,
+    pub changed_vmods: c_uint,
+    pub changed_groups: c_uint,
+    pub changed_indicators: c_uint,
+    pub first_key: c_int,
+    pub num_keys: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XkbCompatMapNotifyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub time: Time,
-  pub xkb_type: c_int,
-  pub device: c_int,
-  pub changed_groups: c_uint,
-  pub first_si: c_int,
-  pub num_si: c_int,
-  pub num_total_si: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub time: Time,
+    pub xkb_type: c_int,
+    pub device: c_int,
+    pub changed_groups: c_uint,
+    pub first_si: c_int,
+    pub num_si: c_int,
+    pub num_total_si: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XkbBellNotifyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub time: Time,
-  pub xkb_type: c_int,
-  pub device: c_int,
-  pub percent: c_int,
-  pub pitch: c_int,
-  pub duration: c_int,
-  pub bell_class: c_int,
-  pub bell_id: c_int,
-  pub name: Atom,
-  pub window: Window,
-  pub event_only: Bool,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub time: Time,
+    pub xkb_type: c_int,
+    pub device: c_int,
+    pub percent: c_int,
+    pub pitch: c_int,
+    pub duration: c_int,
+    pub bell_class: c_int,
+    pub bell_id: c_int,
+    pub name: Atom,
+    pub window: Window,
+    pub event_only: Bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XkbActionMessageEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub time: Time,
-  pub xkb_type: c_int,
-  pub device: c_int,
-  pub keycode: KeyCode,
-  pub press: Bool,
-  pub key_event_follows: Bool,
-  pub group: c_int,
-  pub mods: c_uint,
-  pub message: [c_char; XkbActionMessageLength + 1],
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub time: Time,
+    pub xkb_type: c_int,
+    pub device: c_int,
+    pub keycode: KeyCode,
+    pub press: Bool,
+    pub key_event_follows: Bool,
+    pub group: c_int,
+    pub mods: c_uint,
+    pub message: [c_char; XkbActionMessageLength + 1],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XkbAccessXNotifyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub time: Time,
-  pub xkb_type: c_int,
-  pub device: c_int,
-  pub detail: c_int,
-  pub keycode: c_int,
-  pub sk_delay: c_int,
-  pub debounce_delay: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub time: Time,
+    pub xkb_type: c_int,
+    pub device: c_int,
+    pub detail: c_int,
+    pub keycode: c_int,
+    pub sk_delay: c_int,
+    pub debounce_delay: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XkbExtensionDeviceNotifyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub time: Time,
-  pub xkb_type: c_int,
-  pub device: c_int,
-  pub reason: c_uint,
-  pub supported: c_uint,
-  pub unsupported: c_uint,
-  pub first_btn: c_int,
-  pub num_btns: c_int,
-  pub leds_defined: c_uint,
-  pub led_state: c_uint,
-  pub led_class: c_int,
-  pub led_id: c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub time: Time,
+    pub xkb_type: c_int,
+    pub device: c_int,
+    pub reason: c_uint,
+    pub supported: c_uint,
+    pub unsupported: c_uint,
+    pub first_btn: c_int,
+    pub num_btns: c_int,
+    pub leds_defined: c_uint,
+    pub led_state: c_uint,
+    pub led_class: c_int,
+    pub led_id: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XkbEvent {
-  _pad: [c_long; 24],
+    _pad: [c_long; 24],
 }
 
 #[cfg(test)]
@@ -1968,539 +1982,537 @@ macro_rules! test_xkb_event_size {
 }
 
 #[test]
-fn xkb_event_size_test () {
-  test_xkb_event_size! {
-    XkbAnyEvent,
-    XkbNewKeyboardNotifyEvent,
-    XkbMapNotifyEvent,
-    XkbStateNotifyEvent,
-    XkbControlsNotifyEvent,
-    XkbIndicatorNotifyEvent,
-    XkbNamesNotifyEvent,
-    XkbCompatMapNotifyEvent,
-    XkbBellNotifyEvent,
-    XkbActionMessageEvent,
-    XkbAccessXNotifyEvent,
-    XkbExtensionDeviceNotifyEvent,
-  }
+fn xkb_event_size_test() {
+    test_xkb_event_size! {
+      XkbAnyEvent,
+      XkbNewKeyboardNotifyEvent,
+      XkbMapNotifyEvent,
+      XkbStateNotifyEvent,
+      XkbControlsNotifyEvent,
+      XkbIndicatorNotifyEvent,
+      XkbNamesNotifyEvent,
+      XkbCompatMapNotifyEvent,
+      XkbBellNotifyEvent,
+      XkbActionMessageEvent,
+      XkbAccessXNotifyEvent,
+      XkbExtensionDeviceNotifyEvent,
+    }
 }
 
 pub enum XkbKbdDpyStateRec {}
 pub type XkbKbdDpyStatePtr = *mut XkbKbdDpyStateRec;
 
-
 //
 // other structures
 //
 
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct Depth {
-  pub depth: c_int,
-  pub nvisuals: c_int,
-  pub visuals: *mut Visual,
+    pub depth: c_int,
+    pub nvisuals: c_int,
+    pub visuals: *mut Visual,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct Screen {
-  pub ext_data: *mut XExtData,
-  pub display: *mut Display,
-  pub root: Window,
-  pub width: c_int,
-  pub height: c_int,
-  pub mwidth: c_int,
-  pub mheight: c_int,
-  pub ndepths: c_int,
-  pub depths: *mut Depth,
-  pub root_depth: c_int,
-  pub root_visual: *mut Visual,
-  pub default_gc: GC,
-  pub cmap: Colormap,
-  pub white_pixel: c_ulong,
-  pub black_pixel: c_ulong,
-  pub max_maps: c_int,
-  pub min_maps: c_int,
-  pub backing_store: c_int,
-  pub save_unders: Bool,
-  pub root_input_mask: c_long,
+    pub ext_data: *mut XExtData,
+    pub display: *mut Display,
+    pub root: Window,
+    pub width: c_int,
+    pub height: c_int,
+    pub mwidth: c_int,
+    pub mheight: c_int,
+    pub ndepths: c_int,
+    pub depths: *mut Depth,
+    pub root_depth: c_int,
+    pub root_visual: *mut Visual,
+    pub default_gc: GC,
+    pub cmap: Colormap,
+    pub white_pixel: c_ulong,
+    pub black_pixel: c_ulong,
+    pub max_maps: c_int,
+    pub min_maps: c_int,
+    pub backing_store: c_int,
+    pub save_unders: Bool,
+    pub root_input_mask: c_long,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct ScreenFormat {
-  pub ext_data: *mut XExtData,
-  pub depth: c_int,
-  pub bits_per_pixel: c_int,
-  pub scanline_pad: c_int,
+    pub ext_data: *mut XExtData,
+    pub depth: c_int,
+    pub bits_per_pixel: c_int,
+    pub scanline_pad: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct Visual {
-  pub ext_data: *mut XExtData,
-  pub visualid: VisualID,
-  pub class: c_int,
-  pub red_mask: c_ulong,
-  pub green_mask: c_ulong,
-  pub blue_mask: c_ulong,
-  pub bits_per_rgb: c_int,
-  pub map_entries: c_int,
+    pub ext_data: *mut XExtData,
+    pub visualid: VisualID,
+    pub class: c_int,
+    pub red_mask: c_ulong,
+    pub green_mask: c_ulong,
+    pub blue_mask: c_ulong,
+    pub bits_per_rgb: c_int,
+    pub map_entries: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XArc {
-  pub x: c_short,
-  pub y: c_short,
-  pub width: c_ushort,
-  pub height: c_ushort,
-  pub angle1: c_short,
-  pub angle2: c_short,
+    pub x: c_short,
+    pub y: c_short,
+    pub width: c_ushort,
+    pub height: c_ushort,
+    pub angle1: c_short,
+    pub angle2: c_short,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XChar2b {
-  pub byte1: c_uchar,
-  pub byte2: c_uchar,
+    pub byte1: c_uchar,
+    pub byte2: c_uchar,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XCharStruct {
-  pub lbearing: c_short,
-  pub rbearing: c_short,
-  pub width: c_short,
-  pub ascent: c_short,
-  pub descent: c_short,
-  pub attributes: c_ushort,
+    pub lbearing: c_short,
+    pub rbearing: c_short,
+    pub width: c_short,
+    pub ascent: c_short,
+    pub descent: c_short,
+    pub attributes: c_ushort,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XClassHint {
-  pub res_name: *mut c_char,
-  pub res_class: *mut c_char,
+    pub res_name: *mut c_char,
+    pub res_class: *mut c_char,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XColor {
-  pub pixel: c_ulong,
-  pub red: c_ushort,
-  pub green: c_ushort,
-  pub blue: c_ushort,
-  pub flags: c_char,
-  pub pad: c_char,
+    pub pixel: c_ulong,
+    pub red: c_ushort,
+    pub green: c_ushort,
+    pub blue: c_ushort,
+    pub flags: c_char,
+    pub pad: c_char,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XComposeStatus {
-  pub compose_ptr: XPointer,
-  pub chars_matched: c_int,
+    pub compose_ptr: XPointer,
+    pub chars_matched: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XExtCodes {
-  pub extension: c_int,
-  pub major_opcode: c_int,
-  pub first_event: c_int,
-  pub first_error: c_int,
+    pub extension: c_int,
+    pub major_opcode: c_int,
+    pub first_event: c_int,
+    pub first_error: c_int,
 }
 
 #[repr(C)]
 pub struct XExtData {
-  pub number: c_int,
-  pub next: *mut XExtData,
-  pub free_private: Option<unsafe extern "C" fn () -> c_int>,
-  pub private_data: XPointer,
+    pub number: c_int,
+    pub next: *mut XExtData,
+    pub free_private: Option<unsafe extern "C" fn() -> c_int>,
+    pub private_data: XPointer,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XFontProp {
-  pub name: Atom,
-  pub card32: c_ulong,
+    pub name: Atom,
+    pub card32: c_ulong,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XFontSetExtents {
-  pub max_ink_extent: XRectangle,
-  pub max_logical_extent: XRectangle,
+    pub max_ink_extent: XRectangle,
+    pub max_logical_extent: XRectangle,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XFontStruct {
-  pub ext_data: *mut XExtData,
-  pub fid: Font,
-  pub direction: c_uint,
-  pub min_char_or_byte2: c_uint,
-  pub max_char_or_byte2: c_uint,
-  pub min_byte1: c_uint,
-  pub max_byte1: c_uint,
-  pub all_chars_exist: Bool,
-  pub default_char: c_uint,
-  pub n_properties: c_int,
-  pub properties: *mut XFontProp,
-  pub min_bounds: XCharStruct,
-  pub max_bounds: XCharStruct,
-  pub per_char: *mut XCharStruct,
-  pub ascent: c_int,
-  pub descent: c_int,
+    pub ext_data: *mut XExtData,
+    pub fid: Font,
+    pub direction: c_uint,
+    pub min_char_or_byte2: c_uint,
+    pub max_char_or_byte2: c_uint,
+    pub min_byte1: c_uint,
+    pub max_byte1: c_uint,
+    pub all_chars_exist: Bool,
+    pub default_char: c_uint,
+    pub n_properties: c_int,
+    pub properties: *mut XFontProp,
+    pub min_bounds: XCharStruct,
+    pub max_bounds: XCharStruct,
+    pub per_char: *mut XCharStruct,
+    pub ascent: c_int,
+    pub descent: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XGCValues {
-  pub function: c_int,
-  pub plane_mask: c_ulong,
-  pub foreground: c_ulong,
-  pub background: c_ulong,
-  pub line_width: c_int,
-  pub line_style: c_int,
-  pub cap_style: c_int,
-  pub join_style: c_int,
-  pub fill_style: c_int,
-  pub fill_rule: c_int,
-  pub arc_mode: c_int,
-  pub tile: Pixmap,
-  pub stipple: Pixmap,
-  pub ts_x_origin: c_int,
-  pub ts_y_origin: c_int,
-  pub font: Font,
-  pub subwindow_mode: c_int,
-  pub graphics_exposures: Bool,
-  pub clip_x_origin: c_int,
-  pub clip_y_origin: c_int,
-  pub clip_mask: Pixmap,
-  pub dash_offset: c_int,
-  pub dashes: c_char,
+    pub function: c_int,
+    pub plane_mask: c_ulong,
+    pub foreground: c_ulong,
+    pub background: c_ulong,
+    pub line_width: c_int,
+    pub line_style: c_int,
+    pub cap_style: c_int,
+    pub join_style: c_int,
+    pub fill_style: c_int,
+    pub fill_rule: c_int,
+    pub arc_mode: c_int,
+    pub tile: Pixmap,
+    pub stipple: Pixmap,
+    pub ts_x_origin: c_int,
+    pub ts_y_origin: c_int,
+    pub font: Font,
+    pub subwindow_mode: c_int,
+    pub graphics_exposures: Bool,
+    pub clip_x_origin: c_int,
+    pub clip_y_origin: c_int,
+    pub clip_mask: Pixmap,
+    pub dash_offset: c_int,
+    pub dashes: c_char,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XGenericEventCookie {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub extension: c_int,
-  pub evtype: c_int,
-  pub cookie: c_uint,
-  pub data: *mut c_void,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub extension: c_int,
+    pub evtype: c_int,
+    pub cookie: c_uint,
+    pub data: *mut c_void,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XHostAddress {
-  pub family: c_int,
-  pub length: c_int,
-  pub address: *mut c_char,
+    pub family: c_int,
+    pub length: c_int,
+    pub address: *mut c_char,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XIconSize {
-  pub min_width: c_int,
-  pub min_height: c_int,
-  pub max_width: c_int,
-  pub max_height: c_int,
-  pub width_inc: c_int,
-  pub height_inc: c_int,
+    pub min_width: c_int,
+    pub min_height: c_int,
+    pub max_width: c_int,
+    pub max_height: c_int,
+    pub width_inc: c_int,
+    pub height_inc: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XImage {
-  pub width: c_int,
-  pub height: c_int,
-  pub xoffset: c_int,
-  pub format: c_int,
-  pub data: *mut c_char,
-  pub byte_order: c_int,
-  pub bitmap_unit: c_int,
-  pub bitmap_bit_order: c_int,
-  pub bitmap_pad: c_int,
-  pub depth: c_int,
-  pub bytes_per_line: c_int,
-  pub bits_per_pixel: c_int,
-  pub red_mask: c_ulong,
-  pub green_mask: c_ulong,
-  pub blue_mask: c_ulong,
-  pub obdata: XPointer,
-  pub funcs: ImageFns,
+    pub width: c_int,
+    pub height: c_int,
+    pub xoffset: c_int,
+    pub format: c_int,
+    pub data: *mut c_char,
+    pub byte_order: c_int,
+    pub bitmap_unit: c_int,
+    pub bitmap_bit_order: c_int,
+    pub bitmap_pad: c_int,
+    pub depth: c_int,
+    pub bytes_per_line: c_int,
+    pub bits_per_pixel: c_int,
+    pub red_mask: c_ulong,
+    pub green_mask: c_ulong,
+    pub blue_mask: c_ulong,
+    pub obdata: XPointer,
+    pub funcs: ImageFns,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XKeyboardControl {
-  pub key_click_percent: c_int,
-  pub bell_percent: c_int,
-  pub bell_pitch: c_int,
-  pub bell_duration: c_int,
-  pub led: c_int,
-  pub led_mode: c_int,
-  pub key: c_int,
-  pub auto_repeat_mode: c_int,
+    pub key_click_percent: c_int,
+    pub bell_percent: c_int,
+    pub bell_pitch: c_int,
+    pub bell_duration: c_int,
+    pub led: c_int,
+    pub led_mode: c_int,
+    pub key: c_int,
+    pub auto_repeat_mode: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XKeyboardState {
-  pub key_click_percent: c_int,
-  pub bell_percent: c_int,
-  pub bell_pitch: c_uint,
-  pub bell_duration: c_uint,
-  pub led_mask: c_ulong,
-  pub global_auto_repeat: c_int,
-  pub auto_repeats: [c_char; 32],
+    pub key_click_percent: c_int,
+    pub bell_percent: c_int,
+    pub bell_pitch: c_uint,
+    pub bell_duration: c_uint,
+    pub led_mask: c_ulong,
+    pub global_auto_repeat: c_int,
+    pub auto_repeats: [c_char; 32],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XmbTextItem {
-  pub chars: *mut c_char,
-  pub nchars: c_int,
-  pub delta: c_int,
-  pub font_set: XFontSet,
+    pub chars: *mut c_char,
+    pub nchars: c_int,
+    pub delta: c_int,
+    pub font_set: XFontSet,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XModifierKeymap {
-  pub max_keypermod: c_int,
-  pub modifiermap: *mut KeyCode,
+    pub max_keypermod: c_int,
+    pub modifiermap: *mut KeyCode,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XOMCharSetList {
-  pub charset_count: c_int,
-  pub charset_list: *mut *mut c_char,
+    pub charset_count: c_int,
+    pub charset_list: *mut *mut c_char,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XPixmapFormatValues {
-  pub depth: c_int,
-  pub bits_per_pixel: c_int,
-  pub scanline_pad: c_int,
+    pub depth: c_int,
+    pub bits_per_pixel: c_int,
+    pub scanline_pad: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XPoint {
-  pub x: c_short,
-  pub y: c_short,
+    pub x: c_short,
+    pub y: c_short,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XRectangle {
-  pub x: c_short,
-  pub y: c_short,
-  pub width: c_ushort,
-  pub height: c_ushort,
+    pub x: c_short,
+    pub y: c_short,
+    pub width: c_ushort,
+    pub height: c_ushort,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XrmOptionDescRec {
-  pub option: *mut c_char,
-  pub specifier: *mut c_char,
-  pub argKind: XrmOptionKind,
-  pub value: XPointer,
+    pub option: *mut c_char,
+    pub specifier: *mut c_char,
+    pub argKind: XrmOptionKind,
+    pub value: XPointer,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XrmValue {
-  pub size: c_uint,
-  pub addr: XPointer,
+    pub size: c_uint,
+    pub addr: XPointer,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XSegment {
-  pub x1: c_short,
-  pub y1: c_short,
-  pub x2: c_short,
-  pub y2: c_short,
+    pub x1: c_short,
+    pub y1: c_short,
+    pub x2: c_short,
+    pub y2: c_short,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XSetWindowAttributes {
-  pub background_pixmap: Pixmap,
-  pub background_pixel: c_ulong,
-  pub border_pixmap: Pixmap,
-  pub border_pixel: c_ulong,
-  pub bit_gravity: c_int,
-  pub win_gravity: c_int,
-  pub backing_store: c_int,
-  pub backing_planes: c_ulong,
-  pub backing_pixel: c_ulong,
-  pub save_under: Bool,
-  pub event_mask: c_long,
-  pub do_not_propagate_mask: c_long,
-  pub override_redirect: Bool,
-  pub colormap: Colormap,
-  pub cursor: Cursor,
+    pub background_pixmap: Pixmap,
+    pub background_pixel: c_ulong,
+    pub border_pixmap: Pixmap,
+    pub border_pixel: c_ulong,
+    pub bit_gravity: c_int,
+    pub win_gravity: c_int,
+    pub backing_store: c_int,
+    pub backing_planes: c_ulong,
+    pub backing_pixel: c_ulong,
+    pub save_under: Bool,
+    pub event_mask: c_long,
+    pub do_not_propagate_mask: c_long,
+    pub override_redirect: Bool,
+    pub colormap: Colormap,
+    pub cursor: Cursor,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XSizeHints {
-  pub flags: c_long,
-  pub x: c_int,
-  pub y: c_int,
-  pub width: c_int,
-  pub height: c_int,
-  pub min_width: c_int,
-  pub min_height: c_int,
-  pub max_width: c_int,
-  pub max_height: c_int,
-  pub width_inc: c_int,
-  pub height_inc: c_int,
-  pub min_aspect: AspectRatio,
-  pub max_aspect: AspectRatio,
-  pub base_width: c_int,
-  pub base_height: c_int,
-  pub win_gravity: c_int,
+    pub flags: c_long,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub min_width: c_int,
+    pub min_height: c_int,
+    pub max_width: c_int,
+    pub max_height: c_int,
+    pub width_inc: c_int,
+    pub height_inc: c_int,
+    pub min_aspect: AspectRatio,
+    pub max_aspect: AspectRatio,
+    pub base_width: c_int,
+    pub base_height: c_int,
+    pub win_gravity: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XStandardColormap {
-  pub colormap: Colormap,
-  pub red_max: c_ulong,
-  pub red_mult: c_ulong,
-  pub green_max: c_ulong,
-  pub green_mult: c_ulong,
-  pub blue_max: c_ulong,
-  pub blue_mult: c_ulong,
-  pub base_pixel: c_ulong,
-  pub visualid: VisualID,
-  pub killid: XID,
+    pub colormap: Colormap,
+    pub red_max: c_ulong,
+    pub red_mult: c_ulong,
+    pub green_max: c_ulong,
+    pub green_mult: c_ulong,
+    pub blue_max: c_ulong,
+    pub blue_mult: c_ulong,
+    pub base_pixel: c_ulong,
+    pub visualid: VisualID,
+    pub killid: XID,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XTextItem {
-  pub chars: *mut c_char,
-  pub nchars: c_int,
-  pub delta: c_int,
-  pub font: Font,
+    pub chars: *mut c_char,
+    pub nchars: c_int,
+    pub delta: c_int,
+    pub font: Font,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XTextItem16 {
-  pub chars: *mut XChar2b,
-  pub nchars: c_int,
-  pub delta: c_int,
-  pub font: Font,
+    pub chars: *mut XChar2b,
+    pub nchars: c_int,
+    pub delta: c_int,
+    pub font: Font,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XTextProperty {
-  pub value: *mut c_uchar,
-  pub encoding: Atom,
-  pub format: c_int,
-  pub nitems: c_ulong,
+    pub value: *mut c_uchar,
+    pub encoding: Atom,
+    pub format: c_int,
+    pub nitems: c_ulong,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XTimeCoord {
-  pub time: Time,
-  pub x: c_short,
-  pub y: c_short,
+    pub time: Time,
+    pub x: c_short,
+    pub y: c_short,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XVisualInfo {
-  pub visual: *mut Visual,
-  pub visualid: VisualID,
-  pub screen: c_int,
-  pub depth: c_int,
-  pub class: c_int,
-  pub red_mask: c_ulong,
-  pub green_mask: c_ulong,
-  pub blue_mask: c_ulong,
-  pub colormap_size: c_int,
-  pub bits_per_rgb: c_int,
+    pub visual: *mut Visual,
+    pub visualid: VisualID,
+    pub screen: c_int,
+    pub depth: c_int,
+    pub class: c_int,
+    pub red_mask: c_ulong,
+    pub green_mask: c_ulong,
+    pub blue_mask: c_ulong,
+    pub colormap_size: c_int,
+    pub bits_per_rgb: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XwcTextItem {
-  pub chars: *mut wchar_t,
-  pub nchars: c_int,
-  pub delta: c_int,
-  pub font_set: XFontSet,
+    pub chars: *mut wchar_t,
+    pub nchars: c_int,
+    pub delta: c_int,
+    pub font_set: XFontSet,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XWindowAttributes {
-  pub x: c_int,
-  pub y: c_int,
-  pub width: c_int,
-  pub height: c_int,
-  pub border_width: c_int,
-  pub depth: c_int,
-  pub visual: *mut Visual,
-  pub root: Window,
-  pub class: c_int,
-  pub bit_gravity: c_int,
-  pub win_gravity: c_int,
-  pub backing_store: c_int,
-  pub backing_planes: c_ulong,
-  pub backing_pixel: c_ulong,
-  pub save_under: Bool,
-  pub colormap: Colormap,
-  pub map_installed: Bool,
-  pub map_state: c_int,
-  pub all_event_masks: c_long,
-  pub your_event_mask: c_long,
-  pub do_not_propagate_mask: c_long,
-  pub override_redirect: Bool,
-  pub screen: *mut Screen,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub border_width: c_int,
+    pub depth: c_int,
+    pub visual: *mut Visual,
+    pub root: Window,
+    pub class: c_int,
+    pub bit_gravity: c_int,
+    pub win_gravity: c_int,
+    pub backing_store: c_int,
+    pub backing_planes: c_ulong,
+    pub backing_pixel: c_ulong,
+    pub save_under: Bool,
+    pub colormap: Colormap,
+    pub map_installed: Bool,
+    pub map_state: c_int,
+    pub all_event_masks: c_long,
+    pub your_event_mask: c_long,
+    pub do_not_propagate_mask: c_long,
+    pub override_redirect: Bool,
+    pub screen: *mut Screen,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XWindowChanges {
-  pub x: c_int,
-  pub y: c_int,
-  pub width: c_int,
-  pub height: c_int,
-  pub border_width: c_int,
-  pub sibling: Window,
-  pub stack_mode: c_int,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub border_width: c_int,
+    pub sibling: Window,
+    pub stack_mode: c_int,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XWMHints {
-  pub flags: c_long,
-  pub input: Bool,
-  pub initial_state: c_int,
-  pub icon_pixmap: Pixmap,
-  pub icon_window: Window,
-  pub icon_x: c_int,
-  pub icon_y: c_int,
-  pub icon_mask: Pixmap,
-  pub window_group: XID,
+    pub flags: c_long,
+    pub input: Bool,
+    pub initial_state: c_int,
+    pub icon_pixmap: Pixmap,
+    pub icon_window: Window,
+    pub icon_x: c_int,
+    pub icon_y: c_int,
+    pub icon_mask: Pixmap,
+    pub window_group: XID,
 }
 
 #[repr(C)]
@@ -2556,17 +2568,17 @@ pub struct XIMPreeditCaretCallbackStruct {
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub union XIMTextString {
-  pub multi_byte: *mut c_char,
-  pub wide_char: wchar_t,
+    pub multi_byte: *mut c_char,
+    pub wide_char: wchar_t,
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct XIMText {
-  pub length: c_ushort,
-  pub feedback: *mut XIMFeedback,
-  pub encoding_is_wchar: Bool,
-  pub string: XIMTextString,
+    pub length: c_ushort,
+    pub feedback: *mut XIMFeedback,
+    pub encoding_is_wchar: Bool,
+    pub string: XIMTextString,
 }
 
 #[repr(C)]
@@ -2579,72 +2591,71 @@ pub struct XICCallback {
 // anonymous structures
 //
 
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct AspectRatio {
-  pub x: c_int,
-  pub y: c_int,
+    pub x: c_int,
+    pub y: c_int,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[repr(C)]
 pub struct ClientMessageData {
-  longs: [c_long; 5],
+    longs: [c_long; 5],
 }
 
 impl ClientMessageData {
-  pub fn as_bytes (&self) -> &[c_char] {
-    self.as_ref()
-  }
+    pub fn as_bytes(&self) -> &[c_char] {
+        self.as_ref()
+    }
 
-  pub fn as_bytes_mut (&mut self) -> &mut [c_char] {
-    self.as_mut()
-  }
+    pub fn as_bytes_mut(&mut self) -> &mut [c_char] {
+        self.as_mut()
+    }
 
-  pub fn as_longs (&self) -> &[c_long] {
-    self.as_ref()
-  }
+    pub fn as_longs(&self) -> &[c_long] {
+        self.as_ref()
+    }
 
-  pub fn as_longs_mut (&mut self) -> &mut [c_long] {
-    self.as_mut()
-  }
+    pub fn as_longs_mut(&mut self) -> &mut [c_long] {
+        self.as_mut()
+    }
 
-  pub fn as_shorts (&self) -> &[c_short] {
-    self.as_ref()
-  }
+    pub fn as_shorts(&self) -> &[c_short] {
+        self.as_ref()
+    }
 
-  pub fn as_shorts_mut (&mut self) -> &mut [c_short] {
-    self.as_mut()
-  }
+    pub fn as_shorts_mut(&mut self) -> &mut [c_short] {
+        self.as_mut()
+    }
 
-  pub fn get_byte (&self, index: usize) -> c_char {
-    self.as_bytes()[index]
-  }
+    pub fn get_byte(&self, index: usize) -> c_char {
+        self.as_bytes()[index]
+    }
 
-  pub fn get_long (&self, index: usize) -> c_long {
-    self.longs[index]
-  }
+    pub fn get_long(&self, index: usize) -> c_long {
+        self.longs[index]
+    }
 
-  pub fn get_short (&self, index: usize) -> c_short {
-    self.as_shorts()[index]
-  }
+    pub fn get_short(&self, index: usize) -> c_short {
+        self.as_shorts()[index]
+    }
 
-  pub fn new() -> ClientMessageData {
-    ClientMessageData { longs: [0; 5] }
-  }
+    pub fn new() -> ClientMessageData {
+        ClientMessageData { longs: [0; 5] }
+    }
 
-  pub fn set_byte (&mut self, index: usize, value: c_char) {
-    self.as_bytes_mut()[index] = value;
-  }
+    pub fn set_byte(&mut self, index: usize, value: c_char) {
+        self.as_bytes_mut()[index] = value;
+    }
 
-  pub fn set_long (&mut self, index: usize, value: c_long) {
-    self.longs[index] = value;
-  }
+    pub fn set_long(&mut self, index: usize, value: c_long) {
+        self.longs[index] = value;
+    }
 
-  pub fn set_short (&mut self, index: usize, value: c_short) {
-    self.as_shorts_mut()[index] = value;
-  }
+    pub fn set_short(&mut self, index: usize, value: c_short) {
+        self.as_shorts_mut()[index] = value;
+    }
 }
 
 macro_rules! client_message_data_conversions {
@@ -2681,39 +2692,51 @@ client_message_data_conversions! {
 }
 
 #[test]
-fn client_message_size_test () {
-  assert!(::std::mem::size_of::<ClientMessageData>() >= ::std::mem::size_of::<[c_char; 20]>());
-  assert!(::std::mem::size_of::<ClientMessageData>() >= ::std::mem::size_of::<[c_short; 10]>());
+fn client_message_size_test() {
+    assert!(::std::mem::size_of::<ClientMessageData>() >= ::std::mem::size_of::<[c_char; 20]>());
+    assert!(::std::mem::size_of::<ClientMessageData>() >= ::std::mem::size_of::<[c_short; 10]>());
 }
 
 #[derive(Debug, Copy)]
 #[repr(C)]
 pub struct ImageFns {
-  pub create_image: Option<unsafe extern "C" fn (*mut Display, *mut Visual, c_uint, c_int, c_int, *mut c_char, c_uint, c_uint, c_int, c_int) -> *mut XImage>,
-  pub destroy_image: Option<unsafe extern "C" fn (*mut XImage) -> c_int>,
-  pub get_pixel: Option<unsafe extern "C" fn (*mut XImage, c_int, c_int) -> c_ulong>,
-  pub put_pixel: Option<unsafe extern "C" fn (*mut XImage, c_int, c_int, c_ulong) -> c_int>,
-  pub sub_image: Option<unsafe extern "C" fn (*mut XImage, c_int, c_int, c_uint, c_uint) -> *mut XImage>,
-  pub add_pixel: Option<unsafe extern "C" fn (*mut XImage, c_long) -> c_int>,
+    pub create_image: Option<
+        unsafe extern "C" fn(
+            *mut Display,
+            *mut Visual,
+            c_uint,
+            c_int,
+            c_int,
+            *mut c_char,
+            c_uint,
+            c_uint,
+            c_int,
+            c_int,
+        ) -> *mut XImage,
+    >,
+    pub destroy_image: Option<unsafe extern "C" fn(*mut XImage) -> c_int>,
+    pub get_pixel: Option<unsafe extern "C" fn(*mut XImage, c_int, c_int) -> c_ulong>,
+    pub put_pixel: Option<unsafe extern "C" fn(*mut XImage, c_int, c_int, c_ulong) -> c_int>,
+    pub sub_image:
+        Option<unsafe extern "C" fn(*mut XImage, c_int, c_int, c_uint, c_uint) -> *mut XImage>,
+    pub add_pixel: Option<unsafe extern "C" fn(*mut XImage, c_long) -> c_int>,
 }
 
 impl Clone for ImageFns {
-  fn clone (&self) -> ImageFns {
-    *self
-  }
+    fn clone(&self) -> ImageFns {
+        *self
+    }
 }
 
 impl PartialEq for ImageFns {
-  fn eq (&self, rhs: &ImageFns) -> bool {
-    unsafe { mem_eq(self, rhs) }
-  }
+    fn eq(&self, rhs: &ImageFns) -> bool {
+        unsafe { mem_eq(self, rhs) }
+    }
 }
-
 
 //
 // constants
 //
-
 
 // allocate colormap
 pub const AllocNone: c_int = 0;
@@ -2913,12 +2936,12 @@ pub const Mod4MapIndex: c_int = 6;
 pub const Mod5MapIndex: c_int = 7;
 
 // button masks
-pub const Button1Mask: c_uint = (1<<8);
-pub const Button2Mask: c_uint = (1<<9);
-pub const Button3Mask: c_uint = (1<<10);
-pub const Button4Mask: c_uint = (1<<11);
-pub const Button5Mask: c_uint = (1<<12);
-pub const AnyModifier: c_uint = (1<<15);
+pub const Button1Mask: c_uint = (1 << 8);
+pub const Button2Mask: c_uint = (1 << 9);
+pub const Button3Mask: c_uint = (1 << 10);
+pub const Button4Mask: c_uint = (1 << 11);
+pub const Button5Mask: c_uint = (1 << 12);
+pub const AnyModifier: c_uint = (1 << 15);
 
 // Notify modes
 pub const NotifyNormal: c_int = 0;
@@ -2990,15 +3013,14 @@ pub const RevertToNone: c_int = 0;
 pub const RevertToPointerRoot: c_int = 1;
 pub const RevertToParent: c_int = 2;
 
-
 // ConfigureWindow structure
-pub const CWX: c_ushort = (1<<0);
-pub const CWY: c_ushort = (1<<1);
-pub const CWWidth: c_ushort = (1<<2);
-pub const CWHeight: c_ushort = (1<<3);
-pub const CWBorderWidth: c_ushort = (1<<4);
-pub const CWSibling: c_ushort = (1<<5);
-pub const CWStackMode: c_ushort = (1<<6);
+pub const CWX: c_ushort = (1 << 0);
+pub const CWY: c_ushort = (1 << 1);
+pub const CWWidth: c_ushort = (1 << 2);
+pub const CWHeight: c_ushort = (1 << 3);
+pub const CWBorderWidth: c_ushort = (1 << 4);
+pub const CWSibling: c_ushort = (1 << 5);
+pub const CWStackMode: c_ushort = (1 << 6);
 
 // gravity
 pub const ForgetGravity: c_int = 0;
@@ -3141,29 +3163,29 @@ pub const ArcChord: c_int = 0;
 pub const ArcPieSlice: c_int = 1;
 
 // GC components
-pub const GCFunction: c_uint = (1<<0);
-pub const GCPlaneMask: c_uint = (1<<1);
-pub const GCForeground: c_uint = (1<<2);
-pub const GCBackground: c_uint = (1<<3);
-pub const GCLineWidth: c_uint = (1<<4);
-pub const GCLineStyle: c_uint = (1<<5);
-pub const GCCapStyle: c_uint = (1<<6);
-pub const GCJoinStyle: c_uint = (1<<7);
-pub const GCFillStyle: c_uint = (1<<8);
-pub const GCFillRule: c_uint = (1<<9);
-pub const GCTile: c_uint = (1<<10);
-pub const GCStipple: c_uint = (1<<11);
-pub const GCTileStipXOrigin: c_uint = (1<<12);
-pub const GCTileStipYOrigin: c_uint = (1<<13);
-pub const GCFont : c_uint = (1<<14);
-pub const GCSubwindowMode: c_uint = (1<<15);
-pub const GCGraphicsExposures: c_uint = (1<<16);
-pub const GCClipXOrigin: c_uint = (1<<17);
-pub const GCClipYOrigin: c_uint = (1<<18);
-pub const GCClipMask: c_uint = (1<<19);
-pub const GCDashOffset: c_uint = (1<<20);
-pub const GCDashList: c_uint = (1<<21);
-pub const GCArcMode: c_uint = (1<<22);
+pub const GCFunction: c_uint = (1 << 0);
+pub const GCPlaneMask: c_uint = (1 << 1);
+pub const GCForeground: c_uint = (1 << 2);
+pub const GCBackground: c_uint = (1 << 3);
+pub const GCLineWidth: c_uint = (1 << 4);
+pub const GCLineStyle: c_uint = (1 << 5);
+pub const GCCapStyle: c_uint = (1 << 6);
+pub const GCJoinStyle: c_uint = (1 << 7);
+pub const GCFillStyle: c_uint = (1 << 8);
+pub const GCFillRule: c_uint = (1 << 9);
+pub const GCTile: c_uint = (1 << 10);
+pub const GCStipple: c_uint = (1 << 11);
+pub const GCTileStipXOrigin: c_uint = (1 << 12);
+pub const GCTileStipYOrigin: c_uint = (1 << 13);
+pub const GCFont: c_uint = (1 << 14);
+pub const GCSubwindowMode: c_uint = (1 << 15);
+pub const GCGraphicsExposures: c_uint = (1 << 16);
+pub const GCClipXOrigin: c_uint = (1 << 17);
+pub const GCClipYOrigin: c_uint = (1 << 18);
+pub const GCClipMask: c_uint = (1 << 19);
+pub const GCDashOffset: c_uint = (1 << 20);
+pub const GCDashList: c_uint = (1 << 21);
+pub const GCArcMode: c_uint = (1 << 22);
 
 pub const GCLastBit: c_uint = 22;
 
@@ -3187,14 +3209,14 @@ pub const LedModeOff: c_int = 0;
 pub const LedModeOn: c_int = 1;
 
 // masks for ChangeKeyboardControl
-pub const KBKeyClickPercent: c_ulong = (1<<0);
-pub const KBBellPercent: c_ulong = (1<<1);
-pub const KBBellPitch: c_ulong = (1<<2);
-pub const KBBellDuration: c_ulong = (1<<3);
-pub const KBLed: c_ulong = (1<<4);
-pub const KBLedMode: c_ulong = (1<<5);
-pub const KBKey: c_ulong = (1<<6);
-pub const KBAutoRepeatMode: c_ulong = (1<<7);
+pub const KBKeyClickPercent: c_ulong = (1 << 0);
+pub const KBBellPercent: c_ulong = (1 << 1);
+pub const KBBellPitch: c_ulong = (1 << 2);
+pub const KBBellDuration: c_ulong = (1 << 3);
+pub const KBLed: c_ulong = (1 << 4);
+pub const KBLedMode: c_ulong = (1 << 5);
+pub const KBKey: c_ulong = (1 << 6);
+pub const KBAutoRepeatMode: c_ulong = (1 << 7);
 
 pub const MappingSuccess: c_uchar = 0;
 pub const MappingBusy: c_uchar = 1;
@@ -3461,7 +3483,13 @@ pub const IconWindowHint: c_long = 1 << 3;
 pub const IconPositionHint: c_long = 1 << 4;
 pub const IconMaskHint: c_long = 1 << 5;
 pub const WindowGroupHint: c_long = 1 << 6;
-pub const AllHints: c_long = InputHint | StateHint | IconPixmapHint | IconWindowHint | IconPositionHint | IconMaskHint | WindowGroupHint;
+pub const AllHints: c_long = InputHint
+    | StateHint
+    | IconPixmapHint
+    | IconWindowHint
+    | IconPositionHint
+    | IconMaskHint
+    | WindowGroupHint;
 pub const XUrgencyHint: c_long = 1 << 8;
 
 // XICCEncodingStyle
@@ -3471,12 +3499,12 @@ pub const XTextStyle: c_int = 2;
 pub const XStdICCTextStyle: c_int = 3;
 pub const XUTF8StringStyle: c_int = 4;
 
-
 //
 // inline functions
 //
 
-
 #[cfg(feature = "xlib")]
 #[inline]
-pub unsafe fn XUniqueContext () -> XContext { XrmUniqueQuark() }
+pub unsafe fn XUniqueContext() -> XContext {
+    XrmUniqueQuark()
+}

--- a/src/xlib_xcb.rs
+++ b/src/xlib_xcb.rs
@@ -1,5 +1,5 @@
-use std::os::raw::c_void;
 use ::xlib::Display;
+use crate::os_primitives::c_void;
 
 x11_link! { Xlib_xcb, xlib_xcb, ["libX11-xcb.so.1", "libX11-xcb.so"], 1,
     pub fn XGetXCBConnection(_1: *mut Display) -> *mut xcb_connection_t,

--- a/src/xmd.rs
+++ b/src/xmd.rs
@@ -1,9 +1,9 @@
-pub type INT8  = i8;
+pub type INT8 = i8;
 pub type INT16 = i16;
 pub type INT32 = i32;
 pub type INT64 = i64;
 
-pub type CARD8  = u8;
+pub type CARD8 = u8;
 pub type CARD16 = u16;
 pub type CARD32 = u32;
 pub type CARD64 = u64;

--- a/src/xmu.rs
+++ b/src/xmu.rs
@@ -2,40 +2,18 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{
-  c_char,
-  c_int,
-  c_uchar,
-  c_uint,
-  c_ulong,
-  c_void,
-};
 use libc::FILE;
+use crate::os_primitives::{c_char, c_int, c_uchar, c_uint, c_ulong, c_void};
 
 use ::xlib::{
-  Display,
-  GC,
-  Screen,
-  XColor,
-  XComposeStatus,
-  XErrorEvent,
-  XEvent,
-  XKeyEvent,
-  XrmValue,
-  XSizeHints,
-  XStandardColormap,
-  XVisualInfo,
+    Display, Screen, XColor, XComposeStatus, XErrorEvent, XEvent, XKeyEvent, XSizeHints,
+    XStandardColormap, XVisualInfo, XrmValue, GC,
 };
-use ::xt::{
-  Widget,
-  XtAppContext,
-};
-
+use ::xt::{Widget, XtAppContext};
 
 //
 // functions
 //
-
 
 x11_link! { Xmu, xmu, ["libXmu.so.6", "libXmu.so"], 132,
   pub fn XmuAddCloseDisplayHook (_3: *mut Display, _2: Option<unsafe extern "C" fn (*mut Display, *mut c_char) -> c_int>, _1: *mut c_char) -> *mut c_char,
@@ -174,20 +152,25 @@ globals:
   pub static _XA_UTF8_STRING: AtomPtr,
 }
 
-
 //
 // types
 //
 
-
 // TODO structs
-#[repr(C)] pub struct _AtomRec;
-#[repr(C)] pub struct _XmuArea;
-#[repr(C)] pub struct _XmuDisplayQueue;
-#[repr(C)] pub struct _XmuDisplayQueueEntry;
-#[repr(C)] pub struct _XmuScanline;
-#[repr(C)] pub struct _XmuSegment;
-#[repr(C)] pub struct _XmuWidgetNode;
+#[repr(C)]
+pub struct _AtomRec;
+#[repr(C)]
+pub struct _XmuArea;
+#[repr(C)]
+pub struct _XmuDisplayQueue;
+#[repr(C)]
+pub struct _XmuDisplayQueueEntry;
+#[repr(C)]
+pub struct _XmuScanline;
+#[repr(C)]
+pub struct _XmuSegment;
+#[repr(C)]
+pub struct _XmuWidgetNode;
 
 // struct typedefs
 pub type AtomPtr = *mut _AtomRec;

--- a/src/xrandr.rs
+++ b/src/xrandr.rs
@@ -2,16 +2,14 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{ c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort };
+use crate::os_primitives::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort};
 
-use xlib::{ Atom, Bool, Display, Drawable, Status, Time, XEvent, XID, Window };
-use xrender::{ XFixed, XTransform };
-
+use xlib::{Atom, Bool, Display, Drawable, Status, Time, Window, XEvent, XID};
+use xrender::{XFixed, XTransform};
 
 //
 // functions
 //
-
 
 x11_link! { Xrandr, xrandr, ["libXrandr.so.2", "libXrandr.so"], 70,
     pub fn XRRAddOutputMode (dpy: *mut Display, output: RROutput, mode: RRMode) -> (),
@@ -88,11 +86,9 @@ variadic:
 globals:
 }
 
-
 //
 // types
 //
-
 
 pub type Connection = c_ushort;
 pub type Rotation = c_ushort;
@@ -113,7 +109,8 @@ pub struct XRRScreenSize {
     pub mheight: c_int,
 }
 
-#[repr(C)] pub struct XRRScreenConfiguration;
+#[repr(C)]
+pub struct XRRScreenConfiguration;
 
 pub type XRRModeFlags = c_ulong;
 
@@ -275,11 +272,9 @@ pub struct XRRMonitorInfo {
     pub outputs: *mut RROutput,
 }
 
-
 //
 // event structures
 //
-
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
@@ -414,11 +409,9 @@ event_conversions_and_tests! {
   xrr_resource_change_notify: XRRResourceChangeNotifyEvent,
 }
 
-
 //
 // constants
 //
-
 
 pub const RANDR_NAME: &'static str = "RANDR";
 pub const RANDR_MAJOR: c_int = 1;
@@ -428,131 +421,130 @@ pub const RRNumberErrors: c_int = 4;
 pub const RRNumberEvents: c_int = 2;
 pub const RRNumberRequests: c_int = 45;
 
-pub const X_RRQueryVersion:               c_int = 0;
-pub const X_RROldGetScreenInfo:           c_int = 1;
-pub const X_RRSetScreenConfig:            c_int = 2;
+pub const X_RRQueryVersion: c_int = 0;
+pub const X_RROldGetScreenInfo: c_int = 1;
+pub const X_RRSetScreenConfig: c_int = 2;
 pub const X_RROldScreenChangeSelectInput: c_int = 3;
-pub const X_RRSelectInput:                c_int = 4;
-pub const X_RRGetScreenInfo:              c_int = 5;
+pub const X_RRSelectInput: c_int = 4;
+pub const X_RRGetScreenInfo: c_int = 5;
 
-pub const X_RRGetScreenSizeRange:      c_int = 6;
-pub const X_RRSetScreenSize:           c_int = 7;
-pub const X_RRGetScreenResources:      c_int = 8;
-pub const X_RRGetOutputInfo:           c_int = 9;
-pub const X_RRListOutputProperties:    c_int = 10;
-pub const X_RRQueryOutputProperty:     c_int = 11;
+pub const X_RRGetScreenSizeRange: c_int = 6;
+pub const X_RRSetScreenSize: c_int = 7;
+pub const X_RRGetScreenResources: c_int = 8;
+pub const X_RRGetOutputInfo: c_int = 9;
+pub const X_RRListOutputProperties: c_int = 10;
+pub const X_RRQueryOutputProperty: c_int = 11;
 pub const X_RRConfigureOutputProperty: c_int = 12;
-pub const X_RRChangeOutputProperty:    c_int = 13;
-pub const X_RRDeleteOutputProperty:    c_int = 14;
-pub const X_RRGetOutputProperty:       c_int = 15;
-pub const X_RRCreateMode:              c_int = 16;
-pub const X_RRDestroyMode:             c_int = 17;
-pub const X_RRAddOutputMode:           c_int = 18;
-pub const X_RRDeleteOutputMode:        c_int = 19;
-pub const X_RRGetCrtcInfo:             c_int = 20;
-pub const X_RRSetCrtcConfig:           c_int = 21;
-pub const X_RRGetCrtcGammaSize:        c_int = 22;
-pub const X_RRGetCrtcGamma:            c_int = 23;
-pub const X_RRSetCrtcGamma:            c_int = 24;
+pub const X_RRChangeOutputProperty: c_int = 13;
+pub const X_RRDeleteOutputProperty: c_int = 14;
+pub const X_RRGetOutputProperty: c_int = 15;
+pub const X_RRCreateMode: c_int = 16;
+pub const X_RRDestroyMode: c_int = 17;
+pub const X_RRAddOutputMode: c_int = 18;
+pub const X_RRDeleteOutputMode: c_int = 19;
+pub const X_RRGetCrtcInfo: c_int = 20;
+pub const X_RRSetCrtcConfig: c_int = 21;
+pub const X_RRGetCrtcGammaSize: c_int = 22;
+pub const X_RRGetCrtcGamma: c_int = 23;
+pub const X_RRSetCrtcGamma: c_int = 24;
 
 pub const X_RRGetScreenResourcesCurrent: c_int = 25;
-pub const X_RRSetCrtcTransform:          c_int = 26;
-pub const X_RRGetCrtcTransform:          c_int = 27;
-pub const X_RRGetPanning:                c_int = 28;
-pub const X_RRSetPanning:                c_int = 29;
-pub const X_RRSetOutputPrimary:          c_int = 30;
-pub const X_RRGetOutputPrimary:          c_int = 31;
+pub const X_RRSetCrtcTransform: c_int = 26;
+pub const X_RRGetCrtcTransform: c_int = 27;
+pub const X_RRGetPanning: c_int = 28;
+pub const X_RRSetPanning: c_int = 29;
+pub const X_RRSetOutputPrimary: c_int = 30;
+pub const X_RRGetOutputPrimary: c_int = 31;
 
-pub const X_RRGetProviders:              c_int = 32;
-pub const X_RRGetProviderInfo:           c_int = 33;
-pub const X_RRSetProviderOffloadSink:    c_int = 34;
-pub const X_RRSetProviderOutputSource:   c_int = 35;
-pub const X_RRListProviderProperties:    c_int = 36;
-pub const X_RRQueryProviderProperty:     c_int = 37;
+pub const X_RRGetProviders: c_int = 32;
+pub const X_RRGetProviderInfo: c_int = 33;
+pub const X_RRSetProviderOffloadSink: c_int = 34;
+pub const X_RRSetProviderOutputSource: c_int = 35;
+pub const X_RRListProviderProperties: c_int = 36;
+pub const X_RRQueryProviderProperty: c_int = 37;
 pub const X_RRConfigureProviderProperty: c_int = 38;
-pub const X_RRChangeProviderProperty:    c_int = 39;
-pub const X_RRDeleteProviderProperty:    c_int = 40;
-pub const X_RRGetProviderProperty:       c_int = 41;
+pub const X_RRChangeProviderProperty: c_int = 39;
+pub const X_RRDeleteProviderProperty: c_int = 40;
+pub const X_RRGetProviderProperty: c_int = 41;
 
-pub const X_RRGetMonitors:   c_int = 42;
-pub const X_RRSetMonitor:    c_int = 43;
+pub const X_RRGetMonitors: c_int = 42;
+pub const X_RRSetMonitor: c_int = 43;
 pub const X_RRDeleteMonitor: c_int = 44;
 
-pub const RRTransformUnit:       c_int = 1 << 0;
-pub const RRTransformScaleUp:    c_int = 1 << 1;
-pub const RRTransformScaleDown:  c_int = 1 << 2;
+pub const RRTransformUnit: c_int = 1 << 0;
+pub const RRTransformScaleUp: c_int = 1 << 1;
+pub const RRTransformScaleDown: c_int = 1 << 2;
 pub const RRTransformProjective: c_int = 1 << 3;
 
-pub const RRScreenChangeNotifyMask:     c_int = 1 << 0;
-pub const RRCrtcChangeNotifyMask:       c_int = 1 << 1;
-pub const RROutputChangeNotifyMask:     c_int = 1 << 2;
-pub const RROutputPropertyNotifyMask:   c_int = 1 << 3;
-pub const RRProviderChangeNotifyMask:   c_int = 1 << 4;
+pub const RRScreenChangeNotifyMask: c_int = 1 << 0;
+pub const RRCrtcChangeNotifyMask: c_int = 1 << 1;
+pub const RROutputChangeNotifyMask: c_int = 1 << 2;
+pub const RROutputPropertyNotifyMask: c_int = 1 << 3;
+pub const RRProviderChangeNotifyMask: c_int = 1 << 4;
 pub const RRProviderPropertyNotifyMask: c_int = 1 << 5;
-pub const RRResourceChangeNotifyMask:   c_int = 1 << 6;
+pub const RRResourceChangeNotifyMask: c_int = 1 << 6;
 
-pub const RRScreenChangeNotify:      c_int = 0;
-pub const RRNotify:                  c_int = 1;
-pub const RRNotify_CrtcChange:       c_int = 0;
-pub const RRNotify_OutputChange:     c_int = 1;
-pub const RRNotify_OutputProperty:   c_int = 2;
-pub const RRNotify_ProviderChange:   c_int = 3;
+pub const RRScreenChangeNotify: c_int = 0;
+pub const RRNotify: c_int = 1;
+pub const RRNotify_CrtcChange: c_int = 0;
+pub const RRNotify_OutputChange: c_int = 1;
+pub const RRNotify_OutputProperty: c_int = 2;
+pub const RRNotify_ProviderChange: c_int = 3;
 pub const RRNotify_ProviderProperty: c_int = 4;
-pub const RRNotify_ResourceChange:   c_int = 5;
+pub const RRNotify_ResourceChange: c_int = 5;
 
-pub const RR_Rotate_0:   c_int = 1;
-pub const RR_Rotate_90:  c_int = 2;
+pub const RR_Rotate_0: c_int = 1;
+pub const RR_Rotate_90: c_int = 2;
 pub const RR_Rotate_180: c_int = 4;
 pub const RR_Rotate_270: c_int = 8;
 
 pub const RR_Reflect_X: c_int = 16;
 pub const RR_Reflect_Y: c_int = 32;
 
-pub const RRSetConfigSuccess:           c_int = 0;
+pub const RRSetConfigSuccess: c_int = 0;
 pub const RRSetConfigInvalidConfigTime: c_int = 1;
-pub const RRSetConfigInvalidTime:       c_int = 2;
-pub const RRSetConfigFailed:            c_int = 3;
+pub const RRSetConfigInvalidTime: c_int = 2;
+pub const RRSetConfigFailed: c_int = 3;
 
-pub const RR_HSyncPositive:  c_int = 0x00000001;
-pub const RR_HSyncNegative:  c_int = 0x00000002;
-pub const RR_VSyncPositive:  c_int = 0x00000004;
-pub const RR_VSyncNegative:  c_int = 0x00000008;
-pub const RR_Interlace:      c_int = 0x00000010;
-pub const RR_DoubleScan:     c_int = 0x00000020;
-pub const RR_CSync:          c_int = 0x00000040;
-pub const RR_CSyncPositive:  c_int = 0x00000080;
-pub const RR_CSyncNegative:  c_int = 0x00000100;
-pub const RR_HSkewPresent:   c_int = 0x00000200;
-pub const RR_BCast:          c_int = 0x00000400;
+pub const RR_HSyncPositive: c_int = 0x00000001;
+pub const RR_HSyncNegative: c_int = 0x00000002;
+pub const RR_VSyncPositive: c_int = 0x00000004;
+pub const RR_VSyncNegative: c_int = 0x00000008;
+pub const RR_Interlace: c_int = 0x00000010;
+pub const RR_DoubleScan: c_int = 0x00000020;
+pub const RR_CSync: c_int = 0x00000040;
+pub const RR_CSyncPositive: c_int = 0x00000080;
+pub const RR_CSyncNegative: c_int = 0x00000100;
+pub const RR_HSkewPresent: c_int = 0x00000200;
+pub const RR_BCast: c_int = 0x00000400;
 pub const RR_PixelMultiplex: c_int = 0x00000800;
-pub const RR_DoubleClock:    c_int = 0x00001000;
+pub const RR_DoubleClock: c_int = 0x00001000;
 pub const RR_ClockDivideBy2: c_int = 0x00002000;
 
-pub const RR_Connected:         c_int = 0;
-pub const RR_Disconnected:      c_int = 1;
+pub const RR_Connected: c_int = 0;
+pub const RR_Disconnected: c_int = 1;
 pub const RR_UnknownConnection: c_int = 2;
 
-pub const BadRROutput:   c_int = 0;
-pub const BadRRCrtc:     c_int = 1;
-pub const BadRRMode:     c_int = 2;
+pub const BadRROutput: c_int = 0;
+pub const BadRRCrtc: c_int = 1;
+pub const BadRRMode: c_int = 2;
 pub const BadRRProvider: c_int = 3;
 
-pub const RR_PROPERTY_BACKLIGHT:          &'static str = "Backlight";
-pub const RR_PROPERTY_RANDR_EDID:         &'static str = "EDID";
-pub const RR_PROPERTY_SIGNAL_FORMAT:      &'static str = "SignalFormat";
-pub const RR_PROPERTY_SIGNAL_PROPERTIES:  &'static str = "SignalProperties";
-pub const RR_PROPERTY_CONNECTOR_TYPE:     &'static str = "ConnectorType";
-pub const RR_PROPERTY_CONNECTOR_NUMBER:   &'static str = "ConnectorNumber";
+pub const RR_PROPERTY_BACKLIGHT: &'static str = "Backlight";
+pub const RR_PROPERTY_RANDR_EDID: &'static str = "EDID";
+pub const RR_PROPERTY_SIGNAL_FORMAT: &'static str = "SignalFormat";
+pub const RR_PROPERTY_SIGNAL_PROPERTIES: &'static str = "SignalProperties";
+pub const RR_PROPERTY_CONNECTOR_TYPE: &'static str = "ConnectorType";
+pub const RR_PROPERTY_CONNECTOR_NUMBER: &'static str = "ConnectorNumber";
 pub const RR_PROPERTY_COMPATIBILITY_LIST: &'static str = "CompatibilityList";
-pub const RR_PROPERTY_CLONE_LIST:         &'static str = "CloneList";
-pub const RR_PROPERTY_BORDER:             &'static str = "Border";
-pub const RR_PROPERTY_BORDER_DIMENSIONS:  &'static str = "BorderDimensions";
-pub const RR_PROPERTY_GUID:               &'static str = "GUID";
-pub const RR_PROPERTY_RANDR_TILE:         &'static str = "TILE";
+pub const RR_PROPERTY_CLONE_LIST: &'static str = "CloneList";
+pub const RR_PROPERTY_BORDER: &'static str = "Border";
+pub const RR_PROPERTY_BORDER_DIMENSIONS: &'static str = "BorderDimensions";
+pub const RR_PROPERTY_GUID: &'static str = "GUID";
+pub const RR_PROPERTY_RANDR_TILE: &'static str = "TILE";
 
-pub const RR_Capability_None:          c_int = 0;
-pub const RR_Capability_SourceOutput:  c_int = 1;
-pub const RR_Capability_SinkOutput:    c_int = 2;
+pub const RR_Capability_None: c_int = 0;
+pub const RR_Capability_SourceOutput: c_int = 1;
+pub const RR_Capability_SinkOutput: c_int = 2;
 pub const RR_Capability_SourceOffload: c_int = 4;
-pub const RR_Capability_SinkOffload:   c_int = 8;
-
+pub const RR_Capability_SinkOffload: c_int = 8;

--- a/src/xrecord.rs
+++ b/src/xrecord.rs
@@ -2,26 +2,13 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{
-  c_char,
-  c_int,
-  c_uchar,
-  c_ulong,
-  c_ushort,
-};
+use crate::os_primitives::{c_char, c_int, c_uchar, c_ulong, c_ushort};
 
-use ::xlib::{
-  Bool,
-  Display,
-  Time,
-  XID,
-};
-
+use ::xlib::{Bool, Display, Time, XID};
 
 //
 // functions
 //
-
 
 x11_link! { Xf86vmode, xtst, ["libXtst.so.6", "libXtst.so"], 14,
   pub fn XRecordAllocRange () -> *mut XRecordRange,
@@ -42,11 +29,9 @@ variadic:
 globals:
 }
 
-
 //
 // constants
 //
-
 
 pub const XRecordFromServerTime: c_int = 0x01;
 pub const XRecordFromClientTime: c_int = 0x02;
@@ -63,11 +48,9 @@ pub const XRecordClientDied: c_int = 3;
 pub const XRecordStartOfData: c_int = 4;
 pub const XRecordEndOfData: c_int = 5;
 
-
 //
 // types
 //
-
 
 pub type XRecordClientSpec = c_ulong;
 pub type XRecordContext = c_ulong;
@@ -75,63 +58,63 @@ pub type XRecordContext = c_ulong;
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XRecordClientInfo {
-  pub client: XRecordClientSpec,
-  pub nranges: c_ulong,
-  pub ranges: *mut *mut XRecordRange,
+    pub client: XRecordClientSpec,
+    pub nranges: c_ulong,
+    pub ranges: *mut *mut XRecordRange,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XRecordExtRange {
-  pub ext_major: XRecordRange8,
-  pub ext_minor: XRecordRange16,
+    pub ext_major: XRecordRange8,
+    pub ext_minor: XRecordRange16,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XRecordInterceptData {
-  pub id_base: XID,
-  pub server_time: Time,
-  pub client_seq: c_ulong,
-  pub category: c_int,
-  pub client_swapped: Bool,
-  pub data: *mut c_uchar,
-  pub data_len: c_ulong,
+    pub id_base: XID,
+    pub server_time: Time,
+    pub client_seq: c_ulong,
+    pub category: c_int,
+    pub client_swapped: Bool,
+    pub data: *mut c_uchar,
+    pub data_len: c_ulong,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XRecordRange {
-  pub core_requests: XRecordRange8,
-  pub core_replies: XRecordRange8,
-  pub ext_requests: XRecordExtRange,
-  pub ext_replies: XRecordExtRange,
-  pub delivered_events: XRecordRange8,
-  pub device_events: XRecordRange8,
-  pub errors: XRecordRange8,
-  pub client_started: Bool,
-  pub client_died: Bool,
+    pub core_requests: XRecordRange8,
+    pub core_replies: XRecordRange8,
+    pub ext_requests: XRecordExtRange,
+    pub ext_replies: XRecordExtRange,
+    pub delivered_events: XRecordRange8,
+    pub device_events: XRecordRange8,
+    pub errors: XRecordRange8,
+    pub client_started: Bool,
+    pub client_died: Bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XRecordRange8 {
-  pub first: c_uchar,
-  pub last: c_uchar,
+    pub first: c_uchar,
+    pub last: c_uchar,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XRecordRange16 {
-  pub first: c_ushort,
-  pub last: c_ushort,
+    pub first: c_ushort,
+    pub last: c_ushort,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XRecordState {
-  pub enabled: Bool,
-  pub datum_flags: c_int,
-  pub nclients: c_ulong,
-  pub client_info: *mut *mut XRecordClientInfo,
+    pub enabled: Bool,
+    pub datum_flags: c_int,
+    pub nclients: c_ulong,
+    pub client_info: *mut *mut XRecordClientInfo,
 }

--- a/src/xrender.rs
+++ b/src/xrender.rs
@@ -2,34 +2,13 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{
-  c_char,
-  c_double,
-  c_int,
-  c_short,
-  c_uint,
-  c_ulong,
-  c_ushort,
-};
+use crate::os_primitives::{c_char, c_double, c_int, c_short, c_uint, c_ulong, c_ushort};
 
-use ::xlib::{
-  Atom,
-  Bool,
-  Colormap,
-  Cursor,
-  Display,
-  Pixmap,
-  Region,
-  Visual,
-  XID,
-  XRectangle,
-};
-
+use ::xlib::{Atom, Bool, Colormap, Cursor, Display, Pixmap, Region, Visual, XRectangle, XID};
 
 //
 // functions
 //
-
 
 x11_link! { Xrender, xrender, ["libXrender.so.1", "libXrender.so"], 44,
   pub fn XRenderAddGlyphs (_7: *mut Display, _6: c_ulong, _5: *const c_ulong, _4: *const XGlyphInfo, _3: c_int, _2: *const c_char, _1: c_int) -> (),
@@ -80,11 +59,9 @@ variadic:
 globals:
 }
 
-
 //
 // types
 //
-
 
 pub type Glyph = XID;
 pub type GlyphSet = XID;
@@ -96,233 +73,231 @@ pub type XFixed = c_int;
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XAnimCursor {
-  pub cursor: Cursor,
-  pub delay: c_ulong,
+    pub cursor: Cursor,
+    pub delay: c_ulong,
 }
 pub type XAnimCursor = _XAnimCursor;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XCircle {
-  pub x: XFixed,
-  pub y: XFixed,
-  pub radius: XFixed,
+    pub x: XFixed,
+    pub y: XFixed,
+    pub radius: XFixed,
 }
 pub type XCircle = _XCircle;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XConicalGradient {
-  pub center: XPointFixed,
-  pub angle: XFixed,
+    pub center: XPointFixed,
+    pub angle: XFixed,
 }
 pub type XConicalGradient = _XConicalGradient;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XFilters {
-  pub nfilter: c_int,
-  pub filter: *mut *mut c_char,
-  pub nalias: c_int,
-  pub alias: *mut c_short,
+    pub nfilter: c_int,
+    pub filter: *mut *mut c_char,
+    pub nalias: c_int,
+    pub alias: *mut c_short,
 }
 pub type XFilters = _XFilters;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XGlyphElt8 {
-  pub glyphset: GlyphSet,
-  pub chars: *mut c_char,
-  pub nchars: c_int,
-  pub xOff: c_int,
-  pub yOff: c_int,
+    pub glyphset: GlyphSet,
+    pub chars: *mut c_char,
+    pub nchars: c_int,
+    pub xOff: c_int,
+    pub yOff: c_int,
 }
 pub type XGlyphElt8 = _XGlyphElt8;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XGlyphElt16 {
-  pub glyphset: GlyphSet,
-  pub chars: *mut c_ushort,
-  pub nchars: c_int,
-  pub xOff: c_int,
-  pub yOff: c_int,
+    pub glyphset: GlyphSet,
+    pub chars: *mut c_ushort,
+    pub nchars: c_int,
+    pub xOff: c_int,
+    pub yOff: c_int,
 }
 pub type XGlyphElt16 = _XGlyphElt16;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XGlyphElt32 {
-  pub glyphset: GlyphSet,
-  pub chars: *mut c_uint,
-  pub nchars: c_int,
-  pub xOff: c_int,
-  pub yOff: c_int,
+    pub glyphset: GlyphSet,
+    pub chars: *mut c_uint,
+    pub nchars: c_int,
+    pub xOff: c_int,
+    pub yOff: c_int,
 }
 pub type XGlyphElt32 = _XGlyphElt32;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XGlyphInfo {
-  pub width: c_ushort,
-  pub height: c_ushort,
-  pub x: c_short,
-  pub y: c_short,
-  pub xOff: c_short,
-  pub yOff: c_short,
+    pub width: c_ushort,
+    pub height: c_ushort,
+    pub x: c_short,
+    pub y: c_short,
+    pub xOff: c_short,
+    pub yOff: c_short,
 }
 pub type XGlyphInfo = _XGlyphInfo;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XIndexValue {
-  pub pixel: c_ulong,
-  pub red: c_ushort,
-  pub green: c_ushort,
-  pub blue: c_ushort,
-  pub alpha: c_ushort,
+    pub pixel: c_ulong,
+    pub red: c_ushort,
+    pub green: c_ushort,
+    pub blue: c_ushort,
+    pub alpha: c_ushort,
 }
 pub type XIndexValue = _XIndexValue;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XLinearGradient {
-  pub p1: XPointFixed,
-  pub p2: XPointFixed,
+    pub p1: XPointFixed,
+    pub p2: XPointFixed,
 }
 pub type XLinearGradient = _XLinearGradient;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XLineFixed {
-  pub p1: XPointFixed,
-  pub p2: XPointFixed,
+    pub p1: XPointFixed,
+    pub p2: XPointFixed,
 }
 pub type XLineFixed = _XLineFixed;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XPointDouble {
-  pub x: XDouble,
-  pub y: XDouble,
+    pub x: XDouble,
+    pub y: XDouble,
 }
 pub type XPointDouble = _XPointDouble;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XPointFixed {
-  pub x: XFixed,
-  pub y: XFixed,
+    pub x: XFixed,
+    pub y: XFixed,
 }
 pub type XPointFixed = _XPointFixed;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XRadialGradient {
-  pub inner: XCircle,
-  pub outer: XCircle,
+    pub inner: XCircle,
+    pub outer: XCircle,
 }
 pub type XRadialGradient = _XRadialGradient;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XRenderColor {
-  pub red: c_ushort,
-  pub green: c_ushort,
-  pub blue: c_ushort,
-  pub alpha: c_ushort,
+    pub red: c_ushort,
+    pub green: c_ushort,
+    pub blue: c_ushort,
+    pub alpha: c_ushort,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XRenderDirectFormat {
-  pub red: c_short,
-  pub redMask: c_short,
-  pub green: c_short,
-  pub greenMask: c_short,
-  pub blue: c_short,
-  pub blueMask: c_short,
-  pub alpha: c_short,
-  pub alphaMask: c_short,
+    pub red: c_short,
+    pub redMask: c_short,
+    pub green: c_short,
+    pub greenMask: c_short,
+    pub blue: c_short,
+    pub blueMask: c_short,
+    pub alpha: c_short,
+    pub alphaMask: c_short,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XRenderPictFormat {
-  pub id: PictFormat,
-  pub type_: c_int,
-  pub depth: c_int,
-  pub direct: XRenderDirectFormat,
-  pub colormap: Colormap,
+    pub id: PictFormat,
+    pub type_: c_int,
+    pub depth: c_int,
+    pub direct: XRenderDirectFormat,
+    pub colormap: Colormap,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XRenderPictureAttributes {
-  pub repeat: c_int,
-  pub alpha_map: Picture,
-  pub alpha_x_origin: c_int,
-  pub alpha_y_origin: c_int,
-  pub clip_x_origin: c_int,
-  pub clip_y_origin: c_int,
-  pub clip_mask: Pixmap,
-  pub graphics_exposures: Bool,
-  pub subwindow_mode: c_int,
-  pub poly_edge: c_int,
-  pub poly_mode: c_int,
-  pub dither: Atom,
-  pub component_alpha: Bool,
+    pub repeat: c_int,
+    pub alpha_map: Picture,
+    pub alpha_x_origin: c_int,
+    pub alpha_y_origin: c_int,
+    pub clip_x_origin: c_int,
+    pub clip_y_origin: c_int,
+    pub clip_mask: Pixmap,
+    pub graphics_exposures: Bool,
+    pub subwindow_mode: c_int,
+    pub poly_edge: c_int,
+    pub poly_mode: c_int,
+    pub dither: Atom,
+    pub component_alpha: Bool,
 }
 pub type XRenderPictureAttributes = _XRenderPictureAttributes;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XSpanFix {
-  pub left: XFixed,
-  pub right: XFixed,
-  pub y: XFixed,
+    pub left: XFixed,
+    pub right: XFixed,
+    pub y: XFixed,
 }
 pub type XSpanFix = _XSpanFix;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XTrap {
-  pub top: XSpanFix,
-  pub bottom: XSpanFix,
+    pub top: XSpanFix,
+    pub bottom: XSpanFix,
 }
 pub type XTrap = _XTrap;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XTrapezoid {
-  pub top: XFixed,
-  pub bottom: XFixed,
-  pub left: XLineFixed,
-  pub right: XLineFixed,
+    pub top: XFixed,
+    pub bottom: XFixed,
+    pub left: XLineFixed,
+    pub right: XLineFixed,
 }
 pub type XTrapezoid = _XTrapezoid;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XTriangle {
-  pub p1: XPointFixed,
-  pub p2: XPointFixed,
-  pub p3: XPointFixed,
+    pub p1: XPointFixed,
+    pub p2: XPointFixed,
+    pub p3: XPointFixed,
 }
 pub type XTriangle = _XTriangle;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct _XTransform {
-  pub matrix: [[XFixed; 3]; 3],
+    pub matrix: [[XFixed; 3]; 3],
 }
 pub type XTransform = _XTransform;
-
 
 //
 // constants
 //
-
 
 // pict format mask
 pub const PictFormatID: c_ulong = 1 << 0;

--- a/src/xss.rs
+++ b/src/xss.rs
@@ -2,15 +2,15 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{ c_int, c_uint, c_ulong };
+use crate::os_primitives::{c_int, c_uint, c_ulong};
 
-use xlib::{ Atom, Bool, Display, Drawable, Status, Time, Visual, XEvent, XID, XSetWindowAttributes, Window };
-
+use xlib::{
+    Atom, Bool, Display, Drawable, Status, Time, Visual, Window, XEvent, XSetWindowAttributes, XID,
+};
 
 //
 // functions
 //
-
 
 x11_link! { Xss, xscrnsaver, ["libXss.so.2", "libXss.so"], 11,
   pub fn XScreenSaverQueryExtension (_1: *mut Display, _2: *mut c_int, _3: *mut c_int) -> Bool,
@@ -28,53 +28,47 @@ variadic:
 globals:
 }
 
-
 //
 // types
 //
 
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XScreenSaverInfo {
-  pub window: Window,
-  pub state: c_int,
-  pub kind: c_int,
-  pub til_or_since: c_ulong,
-  pub idle: c_ulong,
-  pub eventMask: c_ulong,
+    pub window: Window,
+    pub state: c_int,
+    pub kind: c_int,
+    pub til_or_since: c_ulong,
+    pub idle: c_ulong,
+    pub eventMask: c_ulong,
 }
-
 
 //
 // event structures
 //
 
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XScreenSaverNotifyEvent {
-  pub type_: c_int,
-  pub serial: c_ulong,
-  pub send_event: Bool,
-  pub display: *mut Display,
-  pub window: Window,
-  pub root: Window,
-  pub state: c_int,
-  pub kind: c_int,
-  pub forced: Bool,
-  pub time: Time,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: Bool,
+    pub display: *mut Display,
+    pub window: Window,
+    pub root: Window,
+    pub state: c_int,
+    pub kind: c_int,
+    pub forced: Bool,
+    pub time: Time,
 }
 
 event_conversions_and_tests! {
   xss_notify: XScreenSaverNotifyEvent,
 }
 
-
 //
 // constants
 //
-
 
 pub const ScreenSaverName: &'static str = "MIT-SCREEN-SAVER";
 pub const ScreenSaverPropertyName: &'static str = "_MIT_SCREEN_SAVER_ID";

--- a/src/xt.rs
+++ b/src/xt.rs
@@ -2,38 +2,16 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{
-  c_char,
-  c_int,
-  c_long,
-  c_short,
-  c_uchar,
-  c_uint,
-  c_ulong,
-  c_ushort,
-  c_void,
-};
+use crate::os_primitives::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort, c_void};
 
 use ::xlib::{
-  Display,
-  GC,
-  Region,
-  Screen,
-  Visual,
-  XEvent,
-  XGCValues,
-  _XrmHashBucketRec,
-  XrmOptionDescList,
-  XrmValue,
-  XSelectionRequestEvent,
-  XSetWindowAttributes,
+    Display, Region, Screen, Visual, XEvent, XGCValues, XSelectionRequestEvent,
+    XSetWindowAttributes, XrmOptionDescList, XrmValue, _XrmHashBucketRec, GC,
 };
-
 
 //
 // functions
 //
-
 
 x11_link! { Xt, xt, ["libXt.so.6", "libXt.so"], 300,
   pub fn XtAddActions (_2: *mut XtActionsRec, _1: c_uint) -> (),
@@ -340,25 +318,35 @@ variadic:
 globals:
 }
 
-
 //
 // types
 //
 
-
 // TODO structs
-#[repr(C)] pub struct Arg;
-#[repr(C)] pub struct SubstitutionRec;
-#[repr(C)] pub struct _TranslationData;
-#[repr(C)] pub struct _WidgetClassRec;
-#[repr(C)] pub struct _WidgetRec;
-#[repr(C)] pub struct _XtActionsRec;
-#[repr(C)] pub struct _XtAppStruct;
-#[repr(C)] pub struct _XtCallbackRec;
-#[repr(C)] pub struct _XtCheckpointTokenRec;
-#[repr(C)] pub struct XtConvertArgRec;
-#[repr(C)] pub struct _XtResource;
-#[repr(C)] pub struct XtWidgetGeometry;
+#[repr(C)]
+pub struct Arg;
+#[repr(C)]
+pub struct SubstitutionRec;
+#[repr(C)]
+pub struct _TranslationData;
+#[repr(C)]
+pub struct _WidgetClassRec;
+#[repr(C)]
+pub struct _WidgetRec;
+#[repr(C)]
+pub struct _XtActionsRec;
+#[repr(C)]
+pub struct _XtAppStruct;
+#[repr(C)]
+pub struct _XtCallbackRec;
+#[repr(C)]
+pub struct _XtCheckpointTokenRec;
+#[repr(C)]
+pub struct XtConvertArgRec;
+#[repr(C)]
+pub struct _XtResource;
+#[repr(C)]
+pub struct XtWidgetGeometry;
 
 // C enums
 pub type XtCallbackStatus = c_int;
@@ -370,13 +358,13 @@ pub type XtListPosition = c_int;
 #[cfg(test)]
 #[repr(C)]
 enum TestEnum {
-  Variant1,
-  Variant2,
+    Variant1,
+    Variant2,
 }
 
 #[test]
-fn enum_size_test () {
-  assert!(::std::mem::size_of::<TestEnum>() == ::std::mem::size_of::<c_int>());
+fn enum_size_test() {
+    assert!(::std::mem::size_of::<TestEnum>() == ::std::mem::size_of::<c_int>());
 }
 
 // struct typedefs

--- a/src/xtest.rs
+++ b/src/xtest.rs
@@ -2,24 +2,14 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-use std::os::raw::{
-  c_int,
-  c_uint,
-  c_ulong,
-};
+use crate::os_primitives::{c_int, c_uint, c_ulong};
 
 use ::xinput::XDevice;
-use ::xlib::{
-  Display,
-  GC,
-  Visual,
-};
-
+use ::xlib::{Display, Visual, GC};
 
 //
 // functions
 //
-
 
 x11_link! { Xf86vmode, xtst, ["libXtst.so.6", "libXtst.so"], 15,
   pub fn XTestCompareCurrentCursorWithWindow (_2: *mut Display, _1: c_ulong) -> c_int,

--- a/x11-dl/src/error.rs
+++ b/x11-dl/src/error.rs
@@ -39,11 +39,11 @@ impl OpenError {
 
 impl Display for OpenError {
   fn fmt (&self, f: &mut Formatter) -> Result<(), ::std::fmt::Error> {
-    try!(f.write_str(self.kind.as_str()));
+    f.write_str(self.kind.as_str())?;
     if !self.detail.is_empty() {
-      try!(f.write_str(" ("));
-      try!(f.write_str(self.detail.as_ref()));
-      try!(f.write_str(")"));
+      f.write_str(" (")?;
+      f.write_str(self.detail.as_ref())?;
+      f.write_str(")")?;
     }
     return Ok(());
   }

--- a/x11-dl/src/lib.rs
+++ b/x11-dl/src/lib.rs
@@ -5,12 +5,20 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+#![allow(unused_parens)]
 
 #[macro_use]
 extern crate lazy_static;
 
 extern crate libc;
 extern crate maybe_uninit;
+extern crate std as core;
+
+// usage of c primitives
+pub(crate) mod os_primitives {
+    // just re-use the std primitives, since this library isn't no_std
+    pub use std::os::raw::*;
+}
 
 #[macro_use]
 mod link;

--- a/x11-dl/src/link.rs
+++ b/x11-dl/src/link.rs
@@ -46,7 +46,7 @@ macro_rules! x11_link {
         }
         let offset = this as usize;
         for &(name, sym_offset) in SYMS.iter() {
-          *((offset + sym_offset) as *mut *mut _) = try!((*this).lib.symbol(name));
+          *((offset + sym_offset) as *mut *mut _) = (*this).lib.symbol(name)?;
         }
         Ok(())
       }
@@ -54,11 +54,11 @@ macro_rules! x11_link {
       pub fn open () -> Result<$struct_name, $crate::error::OpenError> {
         unsafe {
           let libdir = $crate::link::config::libdir::$pkg_name;
-          let lib = try!($crate::link::DynamicLibrary::open_multi(libdir, &[$($lib_name),*]));
+          let lib = $crate::link::DynamicLibrary::open_multi(libdir, &[$($lib_name),*])?;
           let mut this = ::maybe_uninit::MaybeUninit::<$struct_name>::uninit();
           let this_ptr = this.as_mut_ptr();
           ::std::ptr::write(&mut (*this_ptr).lib, lib);
-          try!(Self::init(this_ptr));
+          Self::init(this_ptr)?;
           Ok(this.assume_init())
         }
       }
@@ -154,7 +154,7 @@ impl DynamicLibrary {
         }
 
         let cmsg = CStr::from_ptr(msg as *const c_char);
-        let detail = format!("{} - {}", name, cmsg.to_string_lossy().into_owned());;
+        let detail = format!("{} - {}", name, cmsg.to_string_lossy().into_owned());
         return Err(OpenError::new(OpenErrorKind::Symbol, detail));
       }
 

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -13,8 +13,10 @@ documentation = "https://docs.rs/x11"
 workspace = ".."
 
 [features]
+default = ["std"]
 dpms = []
 glx = []
+std = []
 xcursor = []
 xf86vmode = []
 xft = []

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -6,8 +6,25 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(improper_ctypes)]
+#![allow(unused_parens)]
+#![no_std]
 
 extern crate libc;
+#[cfg(any(test, feature = "std"))]
+extern crate std;
+
+// usage of c primitives
+pub(crate) mod os_primitives {
+    // if we can use std, re-export all of os::raw
+    #[cfg(feature = "std")]
+    pub use std::os::raw::*;
+    // otherwise, re-export the primitives from libc
+    #[cfg(not(feature = "std"))]
+    pub use libc::{
+        c_char, c_double, c_float, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint,
+        c_ulong, c_ulonglong, c_ushort, c_void,
+    };
+}
 
 #[macro_use]
 mod link;
@@ -26,6 +43,7 @@ pub mod xft;
 pub mod xinerama;
 pub mod xinput;
 pub mod xinput2;
+pub mod xlib_xcb;
 pub mod xmd;
 pub mod xmu;
 pub mod xrandr;
@@ -34,4 +52,3 @@ pub mod xrender;
 pub mod xss;
 pub mod xt;
 pub mod xtest;
-pub mod xlib_xcb;


### PR DESCRIPTION
This resolves #93 by turning the `x11` crate into a `#![no_std]` crate. `x11` now has the `std` feature, enabled by default. At the crate root, I have created the crate-private `os_primitives` module. This module will reexport the `std::os::raw` module if the `std` feature is enabled, or reexport the C primitives within `libc` if it is disabled. In this PR, I also cleaned up the code somewhat and ran the `rustfmt` program.

Note that the `x11-dl` crate within this repository still uses `std`. I have modified it slightly to be compatible with the changes described above.