### PR TITLE
Remove maybe-uninit dependency

### DIFF
--- a/x11-dl/Cargo.toml
+++ b/x11-dl/Cargo.toml
@@ -17,7 +17,6 @@ edition = "2018"
 [dependencies]
 lazy_static = "1"
 libc = "0.2"
-maybe-uninit = "2.0.0"
 
 [build-dependencies]
 pkg-config = "0.3.8"

--- a/x11-dl/src/lib.rs
+++ b/x11-dl/src/lib.rs
@@ -12,7 +12,6 @@
 extern crate lazy_static;
 
 extern crate libc;
-extern crate maybe_uninit;
 
 #[macro_use]
 mod link;

--- a/x11-dl/src/link.rs
+++ b/x11-dl/src/link.rs
@@ -53,7 +53,7 @@ macro_rules! x11_link {
         unsafe {
           let libdir = $crate::link::config::libdir::$pkg_name;
           let lib = $crate::link::DynamicLibrary::open_multi(libdir, &[$($lib_name),*])?;
-          let mut this = ::maybe_uninit::MaybeUninit::<$struct_name>::uninit();
+          let mut this = ::std::mem::MaybeUninit::<$struct_name>::uninit();
           let this_ptr = this.as_mut_ptr();
           ::std::ptr::write(&mut (*this_ptr).lib, lib);
           Self::init(this_ptr)?;


### PR DESCRIPTION
This removes the dependency on the maybe-uninit crate
as it's not needed any more.

cc #102