### PR TITLE
Fix typos in Xshm and make Xshm-struct members public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-Updated pkg-config to 0.3.19
+- Updated pkg-config to 0.3.19
+- Correct typos in xshm module
+- Make members of xshm-structs public
 
 ## [2.19.1] - 2021-09-25
 ### Added

--- a/src/xshm.rs
+++ b/src/xshm.rs
@@ -23,23 +23,23 @@ pub type ShmSeg = c_ulong;
 #[repr(C)]
 pub struct XShmCompletionEvent {
     /// of event
-    _type: c_int,
+    pub _type: c_int,
     /// # of last request processed by server
-    serial: c_uint,
+    pub serial: c_uint,
     /// true if this came from a SendEvent request
-    send_event: Bool,
+    pub send_event: Bool,
     /// Display the event was read from
-    diplay: *mut Display,
+    pub diplay: *mut Display,
     /// drawable of request
-    drawable: *mut Drawable,
+    pub drawable: *mut Drawable,
     /// ShmReqCode
-    major_code: c_int,
+    pub major_code: c_int,
     /// X_ShmPutImage
-    minor_code: c_int,
+    pub minor_code: c_int,
     /// the ShmSeg used in the request
-    shmseg: ShmSeg,
+    pub shmseg: ShmSeg,
     /// the offset into ShmSeg used in the request
-    offset: c_ulong,
+    pub offset: c_ulong,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/xshm.rs
+++ b/src/xshm.rs
@@ -22,22 +22,35 @@ pub type ShmSeg = c_ulong;
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
 pub struct XShmCompletionEvent {
+    /// of event
     _type: c_int,
+    /// # of last request processed by server
     serial: c_uint,
+    /// true if this came from a SendEvent request
     send_event: Bool,
+    /// Display the event was read from
     diplay: *mut Display,
+    /// drawable of request
     drawable: *mut Drawable,
+    /// ShmReqCode
     major_code: c_int,
+    /// X_ShmPutImage
     minor_code: c_int,
+    /// the ShmSeg used in the request
     shmseg: ShmSeg,
+    /// the offset into ShmSeg used in the request
     offset: c_ulong,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
 pub struct XShmSegmentInfo {
+    /// resource id
     pub shmseg: ShmSeg,
+    /// kernel id
     pub shmid: c_int,
+    /// address in client
     pub shmaddr: *mut c_char,
+    /// how the server should attach it
     pub readOnly: Bool,
 }

--- a/src/xshm.rs
+++ b/src/xshm.rs
@@ -35,9 +35,9 @@ pub struct XShmCompletionEvent {
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
-pub struct XshmSegmentInfo {
-    shmseg: ShmSeg,
-    shmid: c_int,
-    shmaddr: *mut c_char,
-    readOnly: Bool,
+pub struct XShmSegmentInfo {
+    pub shmseg: ShmSeg,
+    pub shmid: c_int,
+    pub shmaddr: *mut c_char,
+    pub readOnly: Bool,
 }

--- a/src/xshm.rs
+++ b/src/xshm.rs
@@ -6,12 +6,12 @@ x11_link! { Xext, xext, ["libXext.so.6", "libXext.so"], 10,
     pub fn XShmGetEventBase(_1: *mut Display) -> c_int,
     pub fn XShmQueryVersion(_4: *mut Display, _3: *mut c_int, _2: *mut c_int, _1: *mut Bool) -> Bool,
     pub fn XShmPixmapFormat(_1: *mut Display) -> c_int,
-    pub fn XShmAttach(_2: *mut Display, _1: *mut XshmSegmentInfo) -> Bool,
-    pub fn XShmDetach(_2: *mut Display, _1: *mut XshmSegmentInfo) -> Bool,
+    pub fn XShmAttach(_2: *mut Display, _1: *mut XShmSegmentInfo) -> Bool,
+    pub fn XShmDetach(_2: *mut Display, _1: *mut XShmSegmentInfo) -> Bool,
     pub fn XShmPutImage(_11: *mut Display, _10: Drawable, _9: GC, _8: *mut XImage, _7: c_int, _6: c_int, _5: c_int, _4: c_int, _3: c_uint, _2: c_uint, _1: Bool) -> Bool,
     pub fn XShmGetImage(_6: *mut Display, _5: Drawable, _4: *mut XImage, _3: c_int, _2: c_int, _1: c_uint) -> Bool,
-    pub fn XShmCreateImage(_8: *mut Display, _7: *mut Visual, _6: c_uint, _5: c_int, _4: *mut c_char, _3: *mut XshmSegmentInfo, _2: c_uint, _1: c_uint) -> *mut XImage,
-    pub fn XShmCreatePixMap(_7: *mut Display, _6: Drawable, _5: *mut c_char, _4: *mut XshmSegmentInfo, _3: c_uint, _2: c_uint, _1: c_uint) -> Pixmap,
+    pub fn XShmCreateImage(_8: *mut Display, _7: *mut Visual, _6: c_uint, _5: c_int, _4: *mut c_char, _3: *mut XShmSegmentInfo, _2: c_uint, _1: c_uint) -> *mut XImage,
+    pub fn XShmCreatePixMap(_7: *mut Display, _6: Drawable, _5: *mut c_char, _4: *mut XShmSegmentInfo, _3: c_uint, _2: c_uint, _1: c_uint) -> Pixmap,
 
 variadic:
 globals:

--- a/src/xshm.rs
+++ b/src/xshm.rs
@@ -4,7 +4,7 @@ use std::os::raw::{c_char, c_int, c_uint, c_ulong};
 x11_link! { Xext, xext, ["libXext.so.6", "libXext.so"], 10,
     pub fn XShmQueryExtension(_1: *mut Display) -> Bool,
     pub fn XShmGetEventBase(_1: *mut Display) -> c_int,
-    pub fn XshmQueryVersion(_4: *mut Display, _3: *mut c_int, _2: *mut c_int, _1: *mut Bool) -> Bool,
+    pub fn XShmQueryVersion(_4: *mut Display, _3: *mut c_int, _2: *mut c_int, _1: *mut Bool) -> Bool,
     pub fn XShmPixmapFormat(_1: *mut Display) -> c_int,
     pub fn XShmAttach(_2: *mut Display, _1: *mut XshmSegmentInfo) -> Bool,
     pub fn XShmDetach(_2: *mut Display, _1: *mut XshmSegmentInfo) -> Bool,
@@ -37,7 +37,7 @@ pub struct XShmCompletionEvent {
 #[repr(C)]
 pub struct XshmSegmentInfo {
     shmseg: ShmSeg,
-    smid: c_int,
+    shmid: c_int,
     shmaddr: *mut c_char,
     readOnly: Bool,
 }


### PR DESCRIPTION
Hi,

I'm a user of this lib for [xgifwallpaper](https://github.com/calculon102/xgifwallpaper/) For that, I'm using the Xshm-extension. Thanks for adding support!

This pull-request addresses some minor typos in the xshm module. But really important are the public struct members. Otherwise the module is not usable.

- [x] Tested on an x11 machine
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes
- [ ] Created or updated an example program if it would help users understand this functionality
