### PR TITLE
Update to rust 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated pkg-config to 0.3.19
 - Correct typos in xshm module
 - Make members of xshm-structs public
+- Update crate to rust 2021
 
 ## [2.19.1] - 2021-09-25
 ### Added

--- a/x11-dl/Cargo.toml
+++ b/x11-dl/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/AltF02/x11-rs.git"
 build = "build.rs"
 documentation = "https://docs.rs/x11-dl"
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 lazy_static = "1"

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/AltF02/x11-rs.git"
 build = "build.rs"
 documentation = "https://docs.rs/x11"
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [features]
 all = ["dpms", 


### PR DESCRIPTION
This updates the crate to 2021, although for backwards compatibility I'm probably going to merge this some time later as this was stabilized in [1.56](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)

- [x] Tested on an x11 machine
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes
- [ ] Created or updated an example program if it would help users understand this functionality
