### PR TITLE
Add struct XServerInterpretedAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- XServerInterpretedAddress struct
 
 ### Changed
 - Updated pkg-config to 0.3.24

--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -2249,6 +2249,15 @@ pub struct XHostAddress {
     pub address: *mut c_char,
 }
 
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct XServerInterpretedAddress {
+    pub typelength: c_int,
+    pub valuelength: c_int,
+    pub type_: *mut c_char,
+    pub value: *mut c_char,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XIconSize {


### PR DESCRIPTION
`XServerInterpretedAddress` can be passed into `XHostAddress.address`
with `.family=FamilyServerInterpreted`.

- [x] Tested on an x11 machine
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes
- [ ] Created or updated an example program if it would help users understand this functionality
