### PR TITLE
Added feature flag and pkgconfig-entry for the Xfixes-library to the x11-crate

### DIFF
--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -19,6 +19,7 @@ all = ["dpms",
         "glx", 
         "xcursor", 
         "xf86vmode", 
+        "xfixes",
         "xft", 
         "xinerama", 
         "xinput", 
@@ -51,6 +52,7 @@ xt = []
 xtest = ["xtst"]
 xtst = []
 dox = []
+xfixes = []
 
 [dependencies]
 libc = "0.2"

--- a/x11/build.rs
+++ b/x11/build.rs
@@ -17,6 +17,7 @@ fn main() {
         ("x11-xcb", "1.6", "xlib_xcb"),
         ("xcursor", "1.1", "xcursor"),
         ("xext", "1.3", "dpms"),
+        ("xfixes", "3.1", "xfixes"),
         ("xft", "2.1", "xft"),
         ("xi", "1.7", "xinput"),
         ("xinerama", "1.1", "xinerama"),


### PR DESCRIPTION
See #158 for details.

- [x] Tested on an x11 machine
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes
- [ ] Created or updated an example program if it would help users understand this functionality
