### PR TITLE
fix: add links to tags in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,5 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Field order in [_XkbStateRec](https://github.com/freedesktop/xorg-xserver/blob/master/include/xkbstr.h#L47) struct
 
-[Unreleased]: ../../compare/v2.19.1...HEAD
+[Unreleased]: ../../compare/v2.20.0...HEAD
 [2.19.1]: ../../compare/v2.19.0...v2.19.1
+[2.20.0]: ../../compare/v2.19.1...v2.20.0


### PR DESCRIPTION
- [ ] Tested on an x11 machine
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes
- [ ] Created or updated an example program if it would help users understand this functionality
