### PR TITLE
maint: Avoid loading shared libraries more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
  - Fixed a bug that prevented the `XShm` module from loading.
+ - Ensured that the linked libraries are cached and only loaded once.
 
 ## [2.20.1] - 2022-11-24
 ### Added

--- a/x11-dl/Cargo.toml
+++ b/x11-dl/Cargo.toml
@@ -15,8 +15,8 @@ workspace = ".."
 edition = "2021"
 
 [dependencies]
-lazy_static = "1"
 libc = "0.2"
+once_cell = "1.17.0"
 
 [build-dependencies]
 pkg-config = "0.3.24"

--- a/x11-dl/src/lib.rs
+++ b/x11-dl/src/lib.rs
@@ -8,9 +8,6 @@
 #![allow(deref_nullptr)]
 #![allow(clippy::missing_safety_doc)]
 
-#[macro_use]
-extern crate lazy_static;
-
 extern crate libc;
 
 #[macro_use]


### PR DESCRIPTION
- [x] Tested on an x11 machine
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes
- [x] Created or updated an example program if it would help users understand this functionality

This PR makes it so the X11 linked libraries are only loaded once. This PR also replaces `lazy_static` with the `once_cell` crate, since `lazy_static` has largely been replaced with `once_cell` within the Rust ecosystem.