### PR TITLE
xinput2: add `XIMaskLen` macro translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - FAQ Section in README
+- xinput2: XIMaskLen macro translation
 
 ### Changed
 

--- a/src/xinput2.rs
+++ b/src/xinput2.rs
@@ -21,6 +21,10 @@ pub fn XIMaskIsSet(mask: &[::std::os::raw::c_uchar], event: i32) -> bool {
     (mask[mask_byte(event)] & (1 << (event & 7))) != 0
 }
 
+pub fn XIMaskLen(event: i32) -> usize {
+    mask_byte(event) + 1
+}
+
 //
 // functions
 //

--- a/x11-dl/src/link.rs
+++ b/x11-dl/src/link.rs
@@ -179,11 +179,11 @@ impl DynamicLibrary {
 }
 
 impl Drop for DynamicLibrary {
-  fn drop (&mut self) {
-    unsafe {
-      libc::dlclose(self.handle as *mut _);
+    fn drop(&mut self) {
+        unsafe {
+            libc::dlclose(self.handle as *mut _);
+        }
     }
-  }
 }
 
 unsafe impl Send for DynamicLibrary {}


### PR DESCRIPTION
- [x] Tested on an x11 machine
- [ ] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes
- [ ] Created or updated an example program if it would help users understand this functionality
