### PR TITLE
Allow use of x11 crate with x11-dl API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - FAQ Section in README
+- x11 crate now supports x11-dl API (library structures) for compatibility.
 
 ### Changed
 

--- a/src/xlib_xcb.rs
+++ b/src/xlib_xcb.rs
@@ -8,6 +8,7 @@ x11_link! { Xlib_xcb, xlib_xcb, ["libX11-xcb.so.1", "libX11-xcb.so"], 2,
     globals:
 }
 
+#[repr(C)]
 pub enum XEventQueueOwner {
     XlibOwnsEventQueue = 0,
     XCBOwnsEventQueue = 1,

--- a/x11-dl/src/link.rs
+++ b/x11-dl/src/link.rs
@@ -179,11 +179,11 @@ impl DynamicLibrary {
 }
 
 impl Drop for DynamicLibrary {
-  fn drop (&mut self) {
-    unsafe {
-      libc::dlclose(self.handle as *mut _);
+    fn drop(&mut self) {
+        unsafe {
+            libc::dlclose(self.handle as *mut _);
+        }
     }
-  }
 }
 
 unsafe impl Send for DynamicLibrary {}

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -54,6 +54,9 @@ xtest = ["xtst"]
 xtst = []
 dox = []
 
+# Enable static linking of X11 dependencies.
+static = []
+
 [dependencies]
 libc = "0.2"
 

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -57,6 +57,10 @@ dox = []
 # Enable static linking of X11 dependencies.
 static = []
 
+# Disable linking of X11 libraries. Useful to skip build errors in situations
+# where this library might be pulled in, but not actually used.
+skip-buildrs = []
+
 [dependencies]
 libc = "0.2"
 

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x11"
-version = "2.21.0"
+version = "2.21.999"
 authors = [
     "daggerbot <daggerbot@gmail.com>",
     "Erle Pereira <erle@erlepereira.com>",

--- a/x11/build.rs
+++ b/x11/build.rs
@@ -10,6 +10,9 @@ fn main() {
     if cfg!(feature = "dox") {
         return;
     }
+    if env::var_os("CARGO_FEATURE_SKIP_BUILDRS").is_some() {
+        return
+    }
 
     let deps = [
         ("gl", "1", "glx"),

--- a/x11/build.rs
+++ b/x11/build.rs
@@ -31,12 +31,15 @@ fn main() {
         ("xxf86vm", "1.1", "xf86vmode"),
     ];
 
+    let statik = env::var_os("CARGO_FEATURE_STATIC").is_some();
+
     for &(dep, version, feature) in deps.iter() {
         let var = format!("CARGO_FEATURE_{}", feature.to_uppercase().replace('-', "_"));
         if env::var_os(var).is_none() {
             continue;
         }
         pkg_config::Config::new()
+            .statik(statik)
             .atleast_version(version)
             .probe(dep)
             .unwrap();

--- a/x11/src/error.rs
+++ b/x11/src/error.rs
@@ -1,0 +1,33 @@
+//! No-op library for API compatibility with dynamically loaded version. The compile-time version
+//! will never throw an OpenError.
+
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+#[derive(Clone, Debug)]
+pub struct OpenError;
+
+impl Display for OpenError {
+    fn fmt(&self, _f: &mut Formatter) -> Result<(), ::std::fmt::Error> {
+        Ok(())
+    }
+}
+
+impl Error for OpenError {
+    fn description(&self) -> &str {
+        "unused"
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum OpenErrorKind {
+    Unused,
+}
+
+impl OpenErrorKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OpenErrorKind::Unused => "unused",
+        }
+    }
+}

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -11,6 +11,8 @@
 
 extern crate libc;
 
+pub mod error;
+
 #[macro_use]
 mod link;
 mod internal;

--- a/x11/src/link.rs
+++ b/x11/src/link.rs
@@ -15,8 +15,31 @@ macro_rules! x11_link {
       $(pub fn $vfn_name ($($vparam_name : $vparam_type),+, ...) -> $vret_type;)*
     }
 
-    extern {
+    extern "C" {
       $(pub static $var_name : $var_type;)*
+    }
+
+    #[allow(unused)]
+    #[allow(clippy::manual_non_exhaustive)]
+    pub struct $struct_name {
+      _private: (),
+      $(pub $fn_name: unsafe extern "C" fn ($($param_type),*) -> $ret_type,)*
+      $(pub $vfn_name: unsafe extern "C" fn ($($vparam_type),+, ...) -> $vret_type,)*
+      $(pub $var_name: *mut $var_type,)*
+    }
+
+    unsafe impl Send for $struct_name {}
+    unsafe impl Sync for $struct_name {}
+
+    impl $struct_name {
+      pub fn open () -> Result<$struct_name, $crate::error::OpenError> {
+        Ok($struct_name {
+          _private: (),
+          $($fn_name: $fn_name,)*
+          $($vfn_name: $vfn_name,)*
+          $($var_name: unsafe { ::std::mem::transmute($var_name) },)*
+        })
+      }
     }
   }
 }


### PR DESCRIPTION
This enables using the same client code for both x11 and x11-dl by enabling the generation of library structures for the x11 crate.

The client still has to  dispatch between the two variants using eg. a re-export behind cfg attributes - but once dispatched the API is the same.

- [X] Tested on an x11 machine
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes
- [ ] Created or updated an example program if it would help users understand this functionality
